### PR TITLE
Added a fix for deleted comments not showing pfp

### DIFF
--- a/ui/src/pages/Post/Comment.jsx
+++ b/ui/src/pages/Post/Comment.jsx
@@ -235,6 +235,13 @@ const Comment = ({
   const showAuthorProPic = user ? !user.hideUserProfilePictures : true;
   const proPicRef = useRef(null);
   const renderAuthorProPic = () => {
+    if (deleted) {
+      return (
+        <div className="post-comment-propic" ref={proPicRef}>
+          <DeletedUserProPic />
+        </div>
+      );
+    }
     if (!showAuthorProPic) {
       return <div className={'post-comment-collapse-minus' + (collapsed ? ' is-plus' : '')}></div>;
     }


### PR DESCRIPTION
Fixes #11 

Ideally I feel like this should probably be handled in comment.go in the `stripDeletedInfo` function but it seemed like that would probably be a larger refactor that was likely undesired. 

Feel free to reject. <3