### PR TITLE
Disable zoom on input field after tap

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -4,7 +4,7 @@
     <head>
         <meta charset="UTF-8" />
         <title>Discuit</title>
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         <meta name="color-scheme" content="dark light" />
         <meta name="theme-color" content="#ffffff" />
         <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />


### PR DESCRIPTION
This disables the website to zoom in on the input field when you tap on it, as that forces users to also manually zoom out to see all content