### PR TITLE
Add support for providing a database address

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -15,6 +15,7 @@ addr:
 sessionCookieName: SID
 
 # MariaDB configuration:
+DBAddr: 127.0.0.1 # Required
 dbUser: root # Required
 dbPassword: # Required
 dbName: discuit # Required

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -15,7 +15,7 @@ addr:
 sessionCookieName: SID
 
 # MariaDB configuration:
-DBAddr: 127.0.0.1 # Required
+dbAddr: 127.0.0.1 # Required
 dbUser: root # Required
 dbPassword: # Required
 dbName: discuit # Required

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	SiteDescription string `yaml:"siteDescription"` // Used for meta tags.
 
 	// Primary DB credentials.
+	DBAddr     string `yaml:"dbAddr"`
 	DBUser     string `yaml:"dbUser"`
 	DBPassword string `yaml:"dbPassword"`
 	DBName     string `yaml:"dbName"`


### PR DESCRIPTION
Added support for specifying the address for the MariaDB server via dbAddr. It should make it easier for those who wish to rely on an external database or run it, for example, in WSL2.

If this is merged who ever is running the site would need to add `dbAddr: 127.0.0.1` to the config.yaml file.