### PR TITLE
Adding slight shadow/border to community profile pictures

### DIFF
--- a/ui/src/scss/_community.scss
+++ b/ui/src/scss/_community.scss
@@ -64,6 +64,7 @@
             z-index: 1;
             border-radius: 50%;
             border: 2px solid var(--color-bg);
+            box-shadow: var(--card-shadow);
         }
         .comm-main-top-bar {
             grid-row: 3 / 4;


### PR DESCRIPTION
Adding a slight shadow to comm profile pictures to make sure that comm profile pictures with a white background don't look odd/floating, ie. https://discuit.net/Amsterdam. This is a purely aesthetic change and doesn't change functionality, so I consider it subjective in nature. Feel free to reject, obviously.