### PR TITLE
Update go.mod to use Go 1.21 as minimum required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Built with:
 
 To setup a development environment of Discuit on your local computer:
 
-1.  Install Go by following the instructions at
+1.  Install Go (1.21 or higher) by following the instructions at
     [go.dev.](https://go.dev/doc/install)
 1.  Install MariaDB, Redis, Node.js (and NPM). On Ubuntu, for instance, you might
     have to run the following commands:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/discuitnet/discuit
 
-go 1.20
+go 1.21
 
 require (
 	github.com/SherClockHolmes/webpush-go v1.2.0


### PR DESCRIPTION
This PR updates the `go.mod` file to specify Go version 1.21 since the `slices` package was added to the core library in Go 1.21.