### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# Use Ubuntu as the base image to install Redis, MariaDB, and libvips
+FROM ubuntu:22.04
+
+# Avoid prompts from the package manager during build
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV GOVERSION=1.21.0
+
+# Preconfigure tzdata package
+RUN echo "Etc/UTC" > /etc/timezone && \
+    ln -fs /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends tzdata
+
+# Install dependencies
+RUN apt-get update && apt-get install -y \
+    mariadb-server \
+    redis-server \
+    curl \
+    git \
+    gcc \
+    libvips-dev \
+    musl-dev
+
+# Install Node.js (for React frontend)
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs
+
+# Install Go
+RUN curl -LO https://go.dev/dl/go$GOVERSION.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go$GOVERSION.linux-amd64.tar.gz && \
+    rm go$GOVERSION.linux-amd64.tar.gz
+
+# Set PATH for Go
+ENV PATH=$PATH:/usr/local/go/bin
+
+WORKDIR /app
+
+# Copy the application source code
+COPY . .
+
+# Rename config.default.yml to config.yml
+RUN mv config.default.yaml config.yaml
+
+# Build the backend
+RUN GOOS=linux GOARCH=amd64 go build -o discuit .
+
+# Build the frontend
+RUN cd ui && npm ci && npm run build:prod
+
+# Clean up
+RUN apt-get remove -y curl git gcc nodejs && \
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Copy the entrypoint script to the container
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# Expose the port the app runs on
+EXPOSE 80
+
+# Set the entrypoint script as the default command
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/app/discuit", "-serve"]

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ Built with:
 
 To setup a development environment of Discuit on your local computer:
 
-1.  Install Go by following the instructions at
+1. Install Go by following the instructions at
     [go.dev.](https://go.dev/doc/install)
-1.  Install MariaDB, Redis, Node.js (and NPM). On Ubuntu, for instance, you might
+1. Install MariaDB, Redis, Node.js (and NPM). On Ubuntu, for instance, you might
     have to run the following commands:
 
     ```shell
@@ -36,7 +36,7 @@ To setup a development environment of Discuit on your local computer:
     sudo apt install nodejs npm
     ```
 
-1.  Create a MariaDB database.
+1. Create a MariaDB database.
 
     ```shell
     # Open MariaDB CLI
@@ -49,27 +49,34 @@ To setup a development environment of Discuit on your local computer:
     exit;
     ```
 
-1.  Discuit uses `libvips` for fast image transformations. Make sure it's
+1. Discuit uses `libvips` for fast image transformations. Make sure it's
     installed on your computer. On Ubuntu you can install it with:
     `shell
 sudo apt install libvips
 `
-1.  Clone this repository:
+1. Clone this repository:
+
     ```shell
     git clone https://github.com/discuitnet/discuit.git && cd discuit
     ```
-1.  Create a file named `config.yaml` in the root directory and copy the contents
+
+1. Create a file named `config.yaml` in the root directory and copy the contents
     of `config.default.yaml` into it. And enter the required config parameters in
     `config.yaml`.
-1.  Build the frontend and the backend:
+1. Build the frontend and the backend:
+
     ```shell
     ./build.sh
     ```
-1.  Run migrations:
+
+1. Run migrations:
+
     ```shell
     ./discuit -migrate
     ```
-1.  Start the server:
+
+1. Start the server:
+
     ```shell
     ./discuit -serve
     ```
@@ -77,9 +84,35 @@ sudo apt install libvips
 After creating an account, you can run `./discuit -make-admin username` to make
 a user an admin of the site.
 
-Note: Do not install the `discuit` binary using `go install` or move it somewhere
-else. It uses files in this repository at runtime and so it should only be run
-from the root of this repository.
+### Running with Docker
+
+1. **Build the Docker Image**
+
+    ```shell
+    docker build -t discuit .
+    ```
+
+2. **Run the Docker Container**
+
+    > **Note**: The following command while having a persistent database, the included config.yaml file is not. You will need to mount the file to the container if you want to persist the configuration.
+
+    ```shell
+    docker run -d --name discuit -v discuit-db:/var/lib/mysql -v discuit-redis:/var/lib/redis -v discuit-images:/app/images -p 8080:80 discuit
+    ```
+
+3. **Accessing Discuit**: After the container starts, you can access Discuit by navigating to `http://localhost:8080` on your web browser, or to the specific port if you customized the port mapping.
+
+4. **Stopping the Container**: When you're done, you can stop the container by running:
+
+    ```shell
+    docker stop discuit
+    ```
+
+5. **Starting the Container Again**: To start the container again, use:
+
+    ```shell
+    docker start discuit
+    ```
 
 ### Source code layout
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ sudo apt install libvips-dev
 After creating an account, you can run `./discuit -make-admin username` to make
 a user an admin of the site.
 
+Note: Do not install the discuit binary using go install or move it somewhere else. It uses files in this repository at runtime and so it should only be run from the root of this repository.
+
 ### Running with Docker
 
 1. **Build the Docker Image**

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -16,8 +16,8 @@ sessionCookieName: SID
 
 # MariaDB configuration:
 dbAddr: 127.0.0.1 # Required
-dbUser: root # Required
-dbPassword: # Required
+dbUser: discuit # Required
+dbPassword: discuit # Required
 dbName: discuit # Required
 
 # ReCAPTCHA or hCaptcha secret and site-key:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+# Start MariaDB
+service mariadb start
+
+# Start Redis
+service redis-server start
+
+# Set up initial database if it doesn't exist
+echo "Creating the discuit database if it doesn't already exist..."
+mysql -e "CREATE DATABASE IF NOT EXISTS discuit;"
+
+# TODO: Ensure root access with no password is enabled
+mysql -e "CREATE USER IF NOT EXISTS 'discuit'@'%' IDENTIFIED BY 'discuit';" # !!! FUCK: Don't give access from anywhere !!!
+mysql -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'%';"              # !!! FUCK: Don't give access from anywhere !!!
+
+# Run migrations
+echo "Running migrations..."
+/app/discuit -migrate
+
+# Start the Discuit server
+echo "Starting Discuit..."
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,9 +11,9 @@ service redis-server start
 echo "Creating the discuit database if it doesn't already exist..."
 mysql -e "CREATE DATABASE IF NOT EXISTS discuit;"
 
-# TODO: Ensure root access with no password is enabled
-mysql -e "CREATE USER IF NOT EXISTS 'discuit'@'%' IDENTIFIED BY 'discuit';" # !!! FUCK: Don't give access from anywhere !!!
-mysql -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'%';"              # !!! FUCK: Don't give access from anywhere !!!
+# Create a user for the Discuit server
+mysql -e "CREATE USER IF NOT EXISTS 'discuit'@'127.0.0.1' IDENTIFIED BY 'discuit';"
+mysql -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'127.0.0.1';"
 
 # Run migrations
 echo "Running migrations..."


### PR DESCRIPTION
- This PR supports building a docker image containing Discuit. It also updates from using a root user for the database to the `discuit` user
- Instructions are added to create the image and run the container
- Though if the config.yaml needs to be persisted, you will need to mount the file to the container
- Image is currently restricted to running on amd64 systems

Would close issue #4 