### PR TITLE
Add CONFIG to global constants in eslintrc config

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -28,4 +28,7 @@ module.exports = {
     'jsx-a11y/no-autofocus': 'off',
     'prettier/prettier': ['error', {}, { usePrettierrc: true }], // Use our .prettierrc file as source
   },
+  globals: {
+    CONFIG: 'readonly',
+  },
 };


### PR DESCRIPTION
To fix the recurring "CONFIG not defined" errors by adding `CONFIG` to the global constants in the eslintrc config.