### PR TITLE
Enable ES2020 global variables

### DIFF
--- a/ui/.eslintrc.js
+++ b/ui/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     browser: true, // Enables browser globals like window and document
     amd: true, // Enables require() and define() as global variables as per the amd spec.
     node: true, // Enables Node.js global variables and Node.js scoping.
+    es2020: true, // Enables ECMAScript 2020 for global variables
   },
   plugins: ['simple-import-sort'],
   extends: [


### PR DESCRIPTION
This update ensures that global objects (by example) as Promise and Unint8Array are recognized by ESLint, actually this is not the case.