### PR TITLE
fix: bug in docker image with UI not loading new config.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,10 @@ RUN mv config.default.yaml config.yaml
 RUN GOOS=linux GOARCH=amd64 go build -o discuit .
 
 # Build the frontend
-RUN cd ui && npm ci && npm run build:prod
+RUN cd ui && npm ci
 
 # Clean up
-RUN apt-get remove -y curl git gcc nodejs && \
+RUN apt-get remove -y git gcc && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,6 +15,12 @@ mysql -e "CREATE DATABASE IF NOT EXISTS discuit;"
 mysql -e "CREATE USER IF NOT EXISTS 'discuit'@'127.0.0.1' IDENTIFIED BY 'discuit';"
 mysql -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'127.0.0.1';"
 
+# Build the UI
+echo "Building the UI..."
+cd /app/ui
+npm run build:prod
+cd ..
+
 # Run migrations
 echo "Running migrations..."
 /app/discuit -migrate


### PR DESCRIPTION
Fix bug where if config.yaml is mounted, on reload the new config is not made use of in the UI. This was due to the `npm run build:prod` being in the docker image and using the example config & not using the new one. This was fixed by moving it to the `entrypoint.sh` file, where it will rebuild the UI on every restart of the container.

This was a mistake on my part for placing it in the wrong location.