### PR TITLE
feat: Add development proxy

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,8 @@ import (
 type Config struct {
 	IsDevelopment bool `yaml:"isDevelopment"`
 
-	Addr string `yaml:"addr"`
+	Addr     string `yaml:"addr"`
+	DevProxy string `yaml:"devProxy"`
 
 	SiteName        string `yaml:"siteName"`
 	SiteDescription string `yaml:"siteDescription"` // Used for meta tags.

--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,8 @@ import (
 type Config struct {
 	IsDevelopment bool `yaml:"isDevelopment"`
 
-	Addr        string `yaml:"addr"`
-	StaticProxy string `yaml:"staticProxy"`
+	Addr    string `yaml:"addr"`
+	UIProxy string `yaml:"uiProxy"`
 
 	SiteName        string `yaml:"siteName"`
 	SiteDescription string `yaml:"siteDescription"` // Used for meta tags.

--- a/config/config.go
+++ b/config/config.go
@@ -12,8 +12,8 @@ import (
 type Config struct {
 	IsDevelopment bool `yaml:"isDevelopment"`
 
-	Addr     string `yaml:"addr"`
-	DevProxy string `yaml:"devProxy"`
+	Addr        string `yaml:"addr"`
+	StaticProxy string `yaml:"staticProxy"`
 
 	SiteName        string `yaml:"siteName"`
 	SiteDescription string `yaml:"siteDescription"` // Used for meta tags.

--- a/server/server.go
+++ b/server/server.go
@@ -187,14 +187,14 @@ func New(db *sql.DB, conf *config.Config) (*Server, error) {
 		DB:            db,
 	})
 
-	if conf.DevProxy != "" {
+	if conf.StaticProxy != "" {
 		s.staticRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ses, err := s.sessions.Get(r)
 			if err == nil {
 				s.setInitialCookies(w, r, ses)
 			}
 
-			httputil.ProxyRequest(w, r, conf.DevProxy+r.URL.Path)
+			httputil.ProxyRequest(w, r, conf.StaticProxy+r.URL.Path)
 		})
 	} else {
 		s.staticRouter.PathPrefix("/").HandlerFunc(s.serveSPA)

--- a/server/server.go
+++ b/server/server.go
@@ -187,14 +187,14 @@ func New(db *sql.DB, conf *config.Config) (*Server, error) {
 		DB:            db,
 	})
 
-	if conf.StaticProxy != "" {
+	if conf.UIProxy != "" {
 		s.staticRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ses, err := s.sessions.Get(r)
 			if err == nil {
 				s.setInitialCookies(w, r, ses)
 			}
 
-			httputil.ProxyRequest(w, r, conf.StaticProxy+r.URL.Path)
+			httputil.ProxyRequest(w, r, conf.UIProxy+r.URL.Path)
 		})
 	} else {
 		s.staticRouter.PathPrefix("/").HandlerFunc(s.serveSPA)

--- a/server/server.go
+++ b/server/server.go
@@ -187,7 +187,18 @@ func New(db *sql.DB, conf *config.Config) (*Server, error) {
 		DB:            db,
 	})
 
-	s.staticRouter.PathPrefix("/").HandlerFunc(s.serveSPA)
+	if conf.DevProxy != "" {
+		s.staticRouter.PathPrefix("/").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ses, err := s.sessions.Get(r)
+			if err == nil {
+				s.setInitialCookies(w, r, ses)
+			}
+
+			httputil.ProxyRequest(w, r, conf.DevProxy+r.URL.Path)
+		})
+	} else {
+		s.staticRouter.PathPrefix("/").HandlerFunc(s.serveSPA)
+	}
 	return s, nil
 }
 

--- a/ui/webpack.dev.js
+++ b/ui/webpack.dev.js
@@ -8,7 +8,7 @@ module.exports = merge(common, {
   },
   devtool: 'inline-source-map',
   devServer: {
-    contentBase: './dist',
+    // contentBase: './dist',
     historyApiFallback: true,
   },
 });


### PR DESCRIPTION
- Fixes issue with `npm start` failing due to `contentBase: './dist'` in `webpack.dev.js`
- Allows setting of `devProxy` in config UI dev server

It should make it way easier to work on UI changes rather than having to `npm run build:local` on every update.