### PR TITLE
chore: Update CLI command in README and entrypoint script

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,16 +72,16 @@ sudo apt install libvips-dev
 1.  Run migrations:
 
     ```shell
-    ./discuit -migrate
+    ./discuit migrate
     ```
 
 1.  Start the server:
 
     ```shell
-    ./discuit -serve
+    ./discuit serve
     ```
 
-After creating an account, you can run `./discuit -make-admin username` to make
+After creating an account, you can run `./discuit admin make username` to make
 a user an admin of the site.
 
 Note: Do not install the discuit binary using go install or move it somewhere else. It uses files in this repository at runtime and so it should only be run from the root of this repository.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,7 +23,7 @@ cd ..
 
 # Run migrations
 echo "Running migrations..."
-/app/discuit -migrate
+/app/discuit migrate
 
 # Start the Discuit server
 echo "Starting Discuit..."


### PR DESCRIPTION
The CLI command in the README and entrypoint script has been updated to use the new syntax. This change improves consistency and readability.

@previnder, forgot about updating some other locations where the CLI is used, they should all be good now, my bad