### PR TITLE
Add CORS headers to HTTP responses

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -104,6 +104,21 @@ func serve(ctx *cli.Context) error {
 				http.Redirect(w, r, url.String(), http.StatusMovedPermanently)
 				return
 			}
+
+			// Set CORS headers.
+			origin := r.Header.Get("Origin")
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE")
+			w.Header().Set("Access-Control-Expose-Headers", "Csrf-Token")
+			w.Header().Set("Access-Control-Allow-Headers", "x-csrf-token, Content-Type")
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+
+			// Handle preflight requests.
+			if r.Method == "OPTIONS" {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
 			site.ServeHTTP(w, r)
 		}),
 	}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -110,7 +110,7 @@ func serve(ctx *cli.Context) error {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS, PUT, DELETE")
 			w.Header().Set("Access-Control-Expose-Headers", "Csrf-Token")
-			w.Header().Set("Access-Control-Allow-Headers", "x-csrf-token, Content-Type")
+			w.Header().Set("Access-Control-Allow-Headers", "x-csrf-token, Content-Type, credentials")
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 
 			// Handle preflight requests.


### PR DESCRIPTION
Closes #76 

Everything should be working fine. I tested by replacing requests to `discuit.net/api/*` with `localhost/api/*` in the official client at [discuit.net](https://discuit.net) and everything worked perfectly fine. 