### PR TITLE
Fix: 404 when opening a Discuit image link from Discuit

### DIFF
--- a/ui/src/components/MarkdownBody.jsx
+++ b/ui/src/components/MarkdownBody.jsx
@@ -27,6 +27,9 @@ const MarkdownBody = ({ children, noLinks = false, veryBasic = false }) => {
     if (isInternalLink(props.href)) {
       const url = new URL(props.href, `${window.location.protocol}//${window.location.host}`);
       const to = `${url.pathname}${url.search}${url.hash}`;
+      if (to.startsWith('/images/')) {
+        return <a href={to} rel="noreferrer noopener nofollow" {...props} />;
+      }
       return <Link to={to} {...props} />;
     }
     return <a target="_blank" rel="noreferrer noopener nofollow" {...props} />;

--- a/ui/src/components/MarkdownBody.jsx
+++ b/ui/src/components/MarkdownBody.jsx
@@ -28,7 +28,7 @@ const MarkdownBody = ({ children, noLinks = false, veryBasic = false }) => {
       const url = new URL(props.href, `${window.location.protocol}//${window.location.host}`);
       const to = `${url.pathname}${url.search}${url.hash}`;
       if (to.startsWith('/images/')) {
-        return <a href={to} rel="noreferrer noopener nofollow" {...props} />;
+        return <a href={to} rel="noreferrer noopener nofollow" target="_blank" {...props} />;
       }
       return <Link to={to} {...props} />;
     }


### PR DESCRIPTION
Fixes #102 

All internal links were previously handled with `Link`, this PR adds an exception for internal links that begin with `/images`, which will now instead use `a`.