### PR TITLE
Exclude white large square emoji from Inter

### DIFF
--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -207,23 +207,6 @@ const App = () => {
     if (isOnline) setShowOfflinePage(false);
   }, [isOnline]);
 
-  // Hacky solution for the emoji symbols not lining up in the wordle community.
-  // See issue #108.
-  useEffect(() => {
-    if (location.pathname.split('/').slice(1)[0] === 'wordle') {
-      const el = document.createElement('style');
-      el.innerText = `
-      .markdown-body {
-        font-family: var(--system-font);
-      }
-      `;
-      document.head.append(el);
-      return () => {
-        el.remove();
-      };
-    }
-  }, [location]);
-
   if (!isOnline && showOfflinePage) {
     return <Offline />;
   }

--- a/ui/src/scss/_base.scss
+++ b/ui/src/scss/_base.scss
@@ -6,6 +6,7 @@
     font-weight: 100 900;
     font-display: swap;
     src: url('../assets/fonts/InterVariable.woff2') format('woff2');
+    unicode-range: U+0-2B1B, U+2B1D-10FFF;
 }
 @font-face {
     font-family: InterVariable;
@@ -13,6 +14,7 @@
     font-weight: 100 900;
     font-display: swap;
     src: url('../assets/fonts/InterVariable-Italic.woff2') format('woff2');
+    unicode-range: U+0-2B1B, U+2B1D-10FFF;
 }
 
 :root {


### PR DESCRIPTION
All of the other emojis seem to work fine, just this one that causes issues. We'll fix issues as they come up. If Inter causes too many issues we'll look for a new font, but in the meantime Inter seems to work fine (although some people on Discuit are not happy about the change).

You can also undo the other changes with the hacky temp fix if this PR is better.

Closes #108 