### PR TITLE
chore: Update Docker entrypoint script to use proper migrate command

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,7 +19,7 @@ mysql -e "CREATE USER IF NOT EXISTS 'discuit'@'127.0.0.1' IDENTIFIED BY 'discuit
 mysql -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'127.0.0.1';"
 
 # Run migrations
-/app/discuit migrate
+/app/discuit migrate run
 
 # Build the UI
 echo "Building the UI..."


### PR DESCRIPTION
seems I forgot to update the entry point script to use the proper migrate command, so the docker container will keep restarting. My bad.