### PR TITLE
Enable OpenType glyph composition

### DIFF
--- a/ui/src/scss/_base.scss
+++ b/ui/src/scss/_base.scss
@@ -22,7 +22,7 @@
         sans-serif;
     --system-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif;
     --font: var(--custom-font);
-    --font-features: 'ss04' 1, 'case' 1, 'cv10' 1, 'ccmp' 0;
+    --font-features: 'ss04' 1, 'case' 1, 'cv10' 1, 'ccmp' 1;
     --fs-base: 10px;
     --fs-xs: 1.2rem; // extra small
     --fs-s: 1.3rem; // small


### PR DESCRIPTION
Fixes flags and some other emojis not being displayed properly. 