### PR TITLE
Manually set optical size on Safari 16.0-16.3

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -73,4 +73,16 @@ if (isDeviceIos()) {
     shouldPullToRefresh: () =>
       !window.scrollY && window.getComputedStyle(document.body).overflowY !== 'hidden',
   });
+
+  // Workaround for a bug in Safari 16.0-16.3 where optical size of fonts was not automatically
+  // adjusted based on the font size.
+  // See; https://bugs.webkit.org/show_bug.cgi?id=247987
+  if (
+    (navigator.userAgent.includes('Safari') && navigator.userAgent.includes('Version/16.0')) ||
+    navigator.userAgent.includes('Version/16.1') ||
+    navigator.userAgent.includes('Version/16.2') ||
+    navigator.userAgent.includes('Version/16.3')
+  ) {
+    document.documentElement.classList.add('safari16');
+  }
 }

--- a/ui/src/scss/_base.scss
+++ b/ui/src/scss/_base.scss
@@ -387,6 +387,10 @@ ul {
     // list-style-position: inside;
 }
 
+.safari16 body {
+    font-variation-settings: 'opsz' 14;
+}
+
 code {
     font-family: monospace;
 }


### PR DESCRIPTION
Closes #110

Safari 16.0-16.3 doesn't automatically set the optical size of text causing small text to be rendered way too thin. This PR explicitly sets the optical size to 14 for the affected versions of Safari

14 was chosen as that's the minimum for Inter and would be most legible for smaller text