### PR TITLE
ui: increase .dropdown z index

### DIFF
--- a/ui/src/scss/_components.scss
+++ b/ui/src/scss/_components.scss
@@ -516,7 +516,7 @@
 
 .dropdown {
     position: relative;
-    z-index: 10;
+    z-index: 15;
     > .dropdown-target {
     }
     .dropdown-target {


### PR DESCRIPTION
fixes dropdown menus being rendered below images, as reported [here](https://discuit.net/DiscuitMeta/post/Jsvg2NEh)
