### PR TITLE
User welcome notification

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -93,7 +93,7 @@ func serve(ctx *cli.Context) error {
 			for {
 				if n, err := core.SendWelcomeNotifications(context.TODO(), db, conf.WelcomeCommunity, time.Minute); err != nil {
 					log.Printf("Welcome notification sending daemon error: %v\n", err)
-				} else {
+				} else if n > 0 {
 					log.Printf("%d welcome notifications successfully sent\n", n)
 				}
 				time.Sleep(time.Second * 1)

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -89,14 +89,14 @@ func serve(ctx *cli.Context) error {
 	// Send welcome notifications
 	if conf.WelcomeCommunity != "" {
 		go func() {
-			time.Sleep(time.Second * 5)
+			time.Sleep(time.Second * 1)
 			for {
-				if n, err := core.SendWelcomeNotifications(context.TODO(), db, conf.WelcomeCommunity, time.Minute); err != nil {
+				if n, err := core.SendWelcomeNotifications(context.TODO(), db, conf.WelcomeCommunity, time.Second); err != nil {
 					log.Printf("Welcome notification sending daemon error: %v\n", err)
 				} else {
 					log.Printf("%d welcome notifications successfully sent\n", n)
 				}
-				time.Sleep(time.Second * 5)
+				time.Sleep(time.Second * 1)
 			}
 		}()
 	}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -91,7 +91,7 @@ func serve(ctx *cli.Context) error {
 		go func() {
 			time.Sleep(time.Second * 1)
 			for {
-				if n, err := core.SendWelcomeNotifications(context.TODO(), db, conf.WelcomeCommunity, time.Second); err != nil {
+				if n, err := core.SendWelcomeNotifications(context.TODO(), db, conf.WelcomeCommunity, time.Minute); err != nil {
 					log.Printf("Welcome notification sending daemon error: %v\n", err)
 				} else {
 					log.Printf("%d welcome notifications successfully sent\n", n)

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -86,6 +86,18 @@ func serve(ctx *cli.Context) error {
 		}
 	}()
 
+	go func() {
+		time.Sleep(time.Second * 5)
+		for {
+			if n, err := core.SendWelcomeNotifications(context.TODO(), db, time.Minute); err != nil {
+				log.Printf("Welcome notification sending daemon error: %v\n", err)
+			} else if n > 0 {
+				log.Printf("%d welcome notifications successfully sent\n", n)
+			}
+			time.Sleep(time.Second * 5)
+		}
+	}()
+
 	if !config.AddressValid(conf.Addr) {
 		log.Fatal("Address needs to be a valid address of the form 'host:port' (host can be empty)")
 	}

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -91,9 +91,9 @@ func serve(ctx *cli.Context) error {
 		go func() {
 			time.Sleep(time.Second * 5)
 			for {
-				if n, err := core.SendWelcomeNotifications(context.TODO(), db, time.Minute); err != nil {
+				if n, err := core.SendWelcomeNotifications(context.TODO(), db, conf.WelcomeCommunity, time.Minute); err != nil {
 					log.Printf("Welcome notification sending daemon error: %v\n", err)
-				} else if n > 0 {
+				} else {
 					log.Printf("%d welcome notifications successfully sent\n", n)
 				}
 				time.Sleep(time.Second * 5)

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -86,17 +86,20 @@ func serve(ctx *cli.Context) error {
 		}
 	}()
 
-	go func() {
-		time.Sleep(time.Second * 5)
-		for {
-			if n, err := core.SendWelcomeNotifications(context.TODO(), db, time.Minute); err != nil {
-				log.Printf("Welcome notification sending daemon error: %v\n", err)
-			} else if n > 0 {
-				log.Printf("%d welcome notifications successfully sent\n", n)
-			}
+	// Send welcome notifications
+	if conf.WelcomeCommunity != "" {
+		go func() {
 			time.Sleep(time.Second * 5)
-		}
-	}()
+			for {
+				if n, err := core.SendWelcomeNotifications(context.TODO(), db, time.Minute); err != nil {
+					log.Printf("Welcome notification sending daemon error: %v\n", err)
+				} else if n > 0 {
+					log.Printf("%d welcome notifications successfully sent\n", n)
+				}
+				time.Sleep(time.Second * 5)
+			}
+		}()
+	}
 
 	if !config.AddressValid(conf.Addr) {
 		log.Fatal("Address needs to be a valid address of the form 'host:port' (host can be empty)")

--- a/config/config.go
+++ b/config/config.go
@@ -73,6 +73,8 @@ type Config struct {
 	DiscordURL     string `yaml:"discordURL"`
 	GithubURL      string `yaml:"githubURL"`
 	SubstackURL    string `yaml:"substackURL"`
+
+	WelcomeCommunity string `yaml:"welcomeCommunity"`
 }
 
 // Parse parses the yaml file at path and returns a Config.

--- a/core/notification.go
+++ b/core/notification.go
@@ -955,7 +955,7 @@ func (n *NotificationWelcome) marshalJSONForAPI(ctx context.Context, db *sql.DB)
 	return json.Marshal(out)
 }
 
-func CreateWelcomeNotification(ctx context.Context, db *sql.DB, community string, user uid.ID) error {
+func createWelcomeNotification(ctx context.Context, db *sql.DB, community string, user uid.ID) error {
 	return CreateNotification(ctx, db, user, NotificationTypeWelcome, &NotificationWelcome{
 		CommunityName: community,
 	})
@@ -993,7 +993,7 @@ func SendWelcomeNotifications(ctx context.Context, db *sql.DB, community string,
 
 	// Send a notification to a single user
 	send := func(user uid.ID) error {
-		if err := CreateWelcomeNotification(ctx, db, community, user); err != nil {
+		if err := createWelcomeNotification(ctx, db, community, user); err != nil {
 			return fmt.Errorf("failed to send welcome notification: %w", err)
 		}
 		_, err := db.ExecContext(ctx, "update users set welcome_notification_sent = true where id = ?", user)

--- a/core/notification.go
+++ b/core/notification.go
@@ -973,7 +973,6 @@ func SendWelcomeNotifications(ctx context.Context, db *sql.DB, community string,
 		}
 	}
 
-	// Fetch the users who needs a notification sent
 	rows, err := db.QueryContext(ctx, "SELECT id FROM users WHERE welcome_notification_sent = false AND created_at < ?", time.Now().Add(-1*delay))
 	if err != nil {
 		return 0, err

--- a/core/notification.go
+++ b/core/notification.go
@@ -74,7 +74,8 @@ type Notification struct {
 	UserID uid.ID           `json:"-"`
 	Type   NotificationType `json:"type"`
 
-	// Information specific to notification type.
+	// Information specific to notification type (nil in case there is an error
+	// fetching this resource).
 	Notif        notification `json:"notif"`
 	notifRawJSON []byte
 
@@ -94,11 +95,13 @@ func (n *Notification) MarshalJSON() ([]byte, error) {
 
 	data, err := n.Notif.marshalJSONForAPI(context.TODO(), n.db)
 	if err != nil {
-		return nil, fmt.Errorf("marshalJSONForAPI (notifId: %v): %w", n.ID, err)
-	}
-
-	if err = json.Unmarshal(data, &x.Notif); err != nil {
-		return nil, err
+		// return nil, fmt.Errorf("marshalJSONForAPI (notifId: %v): %w", n.ID, err)
+		// Log the error but continue.
+		log.Printf("marshalJSONForAPI (notifId: %v): %v", n.ID, err)
+	} else {
+		if err = json.Unmarshal(data, &x.Notif); err != nil {
+			return nil, err
+		}
 	}
 
 	return json.Marshal(x)

--- a/core/notification.go
+++ b/core/notification.go
@@ -95,9 +95,9 @@ func (n *Notification) MarshalJSON() ([]byte, error) {
 
 	data, err := n.Notif.marshalJSONForAPI(context.TODO(), n.db)
 	if err != nil {
-		// return nil, fmt.Errorf("marshalJSONForAPI (notifId: %v): %w", n.ID, err)
-		// Log the error but continue.
+		// Log the error but otherwise continue as if no error occurred.
 		log.Printf("marshalJSONForAPI (notifId: %v): %v", n.ID, err)
+		// return nil, fmt.Errorf("marshalJSONForAPI (notifId: %v): %w", n.ID, err)
 	} else {
 		if err = json.Unmarshal(data, &x.Notif); err != nil {
 			return nil, err

--- a/core/notification.go
+++ b/core/notification.go
@@ -146,52 +146,29 @@ func scanNotifications(db *sql.DB, rows *sql.Rows) ([]*Notification, error) {
 	}
 
 	for _, notif := range notifs {
+		var nc notification
 		switch notif.Type {
 		case NotificationTypeNewComment:
-			nc := &NotificationNewComment{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationNewComment{}
 		case NotificationTypeCommentReply:
-			nc := &NotificationCommentReply{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationCommentReply{}
 		case NotificationTypeUpvote:
-			nc := &NotificationNewVotes{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationNewVotes{}
 		case NotificationTypeDeletePost:
-			nc := &NotificationPostDeleted{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationPostDeleted{}
 		case NotificationTypeModAdd:
-			nc := &NotificationModAdd{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationModAdd{}
 		case NotificationTypeNewBadge:
-			nc := &NotificationNewBadge{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationNewBadge{}
 		case NotificationTypeWelcome:
-			nc := &NotificationWelcome{}
-			if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
-				return nil, err
-			}
-			notif.Notif = nc
+			nc = &NotificationWelcome{}
 		default:
 			return nil, fmt.Errorf("unknown notification type: %s", string(notif.Type))
 		}
+		if err := json.Unmarshal(notif.notifRawJSON, nc); err != nil {
+			return nil, err
+		}
+		notif.Notif = nc
 	}
 
 	return notifs, nil

--- a/core/notification.go
+++ b/core/notification.go
@@ -240,7 +240,9 @@ func CreateNotification(ctx context.Context, db *sql.DB, user uid.ID, Type Notif
 			log.Println("Error getting notification (CreateNotification)", err)
 			return
 		}
-		notif.SendPushNotification(ctx)
+		if err = notif.SendPushNotification(ctx); err != nil {
+			log.Printf("Error sending push notification: %v\n", err)
+		}
 	}
 
 	sendPushNotif()

--- a/core/user.go
+++ b/core/user.go
@@ -480,10 +480,6 @@ func RegisterUser(ctx context.Context, db *sql.DB, username, email, password str
 		// Continue on failure.
 	}
 
-	if err := CreateWelcomeNotification(ctx, db, id); err != nil {
-		log.Println("Failed to send welcome notification: ", err)
-	}
-
 	return GetUser(ctx, db, id, nil)
 }
 

--- a/migrations/0048_welcome_notification.down.sql
+++ b/migrations/0048_welcome_notification.down.sql
@@ -1,0 +1,1 @@
+alter table users drop column welcome_notification_sent;

--- a/migrations/0048_welcome_notification.up.sql
+++ b/migrations/0048_welcome_notification.up.sql
@@ -1,0 +1,5 @@
+alter table users add column welcome_notification_sent bool not null default false;
+alter table users add index idx_welcome_notification_sent (welcome_notification_sent);
+
+/* Consider the notification is sent for users older than 7 days. */
+update users set welcome_notification_sent = 1 where created_at < subdate(now(), 7);

--- a/ui/service-worker.js
+++ b/ui/service-worker.js
@@ -233,6 +233,12 @@ const getNotificationInfo = (notification, csrfToken) => {
         setImage(src);
       }
       break;
+    case 'welcome':
+      {
+        ret.title = `Welcome to Discuit! Make a post in our +${notif.community.name} to say hello`;
+        setToURL(`/${notif.community.name}`);
+      }
+      break;
     default: {
       throw new Error('Unkown notification type');
     }

--- a/ui/service-worker.js
+++ b/ui/service-worker.js
@@ -235,7 +235,7 @@ const getNotificationInfo = (notification, csrfToken) => {
       break;
     case 'welcome':
       {
-        ret.title = `Welcome to Discuit! Make a post in our +${notif.community.name} to say hello`;
+        ret.title = `Welcome to Discuit! Make a post in our +${notif.community.name} community to say hello`;
         setToURL(`/${notif.community.name}`);
       }
       break;

--- a/ui/service-worker.js
+++ b/ui/service-worker.js
@@ -159,12 +159,12 @@ const getNotificationInfo = (notification, csrfToken) => {
     // ret.options.badge = '/favicon.png';
   };
 
-  const maxText = (text = '', maxLength = 120) => {
-    if (text.length > maxLength) {
-      return text.substring(0, maxLength) + '...';
-    }
-    return text;
-  };
+  // const maxText = (text = '', maxLength = 120) => {
+  //   if (text.length > maxLength) {
+  //     return text.substring(0, maxLength) + '...';
+  //   }
+  //   return text;
+  // };
 
   const setToURL = (to = '') => {
     ret.options.data.toURL = to;

--- a/ui/src/components/Navbar/NotificationItem.jsx
+++ b/ui/src/components/Navbar/NotificationItem.jsx
@@ -117,7 +117,8 @@ const NotificationItem = ({ notification, ...rest }) => {
       case 'welcome': {
         return (
           <>
-            <b>{notif.title}</b> {notif.body}
+            <b>Welcome to Discuit</b> Make a post in our <b>+{notif.community.name}</b> community to
+            say hello!
           </>
         );
       }
@@ -197,7 +198,8 @@ const NotificationItem = ({ notification, ...rest }) => {
       break;
     }
     case 'welcome':
-      to = notif.url;
+      to = `/${notif.community.name}`;
+      image = getNotifImage(notif);
       break;
   }
 

--- a/ui/src/components/Navbar/NotificationItem.jsx
+++ b/ui/src/components/Navbar/NotificationItem.jsx
@@ -156,6 +156,35 @@ const NotificationItem = ({ notification, ...rest }) => {
     return { url: image, backgroundColor: background };
   };
 
+  const actionsRef = useRef();
+  const history = useHistory();
+  const handleClick = (event, to) => {
+    event.preventDefault();
+    if (
+      !actionsRef.current.contains(event.target) &&
+      !document.querySelector('#modal-root').contains(event.target)
+    ) {
+      if (!seen) handleMarkAsSeen();
+      history.push(to, {
+        fromNotifications: true,
+      });
+    }
+  };
+
+  if (notif === null) {
+    return (
+      <div className="notif" style={{ cursor: 'initial' }}>
+        <div className="notif-icon"></div>
+        <div className="notif-body">Error rendering notification item</div>
+      </div>
+    );
+  }
+
+  const notifText = renderText();
+  if (notifText === null) {
+    return null; // notification type is unknown
+  }
+
   let image = defaultImage;
   let to = '';
   switch (type) {
@@ -203,26 +232,6 @@ const NotificationItem = ({ notification, ...rest }) => {
       break;
   }
 
-  const actionsRef = useRef();
-  const history = useHistory();
-  const handleClick = (e) => {
-    e.preventDefault();
-    if (
-      !actionsRef.current.contains(e.target) &&
-      !document.querySelector('#modal-root').contains(e.target)
-    ) {
-      if (!seen) handleMarkAsSeen();
-      history.push(to, {
-        fromNotifications: true,
-      });
-    }
-  };
-
-  const notifText = renderText();
-  if (notifText === null) {
-    return null; // notification type is unknown
-  }
-
   return (
     <a
       href={to}
@@ -231,7 +240,7 @@ const NotificationItem = ({ notification, ...rest }) => {
         (seen ? ' is-seen' : '') +
         (actionBtnHovering ? ' is-btn-hovering' : '')
       }
-      onClick={handleClick}
+      onClick={(e) => handleClick(e, to)}
       {...rest}
     >
       <div className="notif-icon">

--- a/ui/src/components/Navbar/NotificationItem.jsx
+++ b/ui/src/components/Navbar/NotificationItem.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 import Favicon from '../../assets/imgs/favicon.png';
@@ -114,6 +114,13 @@ const NotificationItem = ({ notification, ...rest }) => {
           </>
         );
       }
+      case 'welcome': {
+        return (
+          <>
+            <b>{notif.title}</b> {notif.body}
+          </>
+        );
+      }
       default: {
         return null; // unknown notification type
       }
@@ -189,6 +196,9 @@ const NotificationItem = ({ notification, ...rest }) => {
       };
       break;
     }
+    case 'welcome':
+      to = notif.url;
+      break;
   }
 
   const actionsRef = useRef();


### PR DESCRIPTION
This PR introduces a new notification type, `welcome`, which is sent to new users sometime after they sign up. Clicking on this notification sends users to a community, specified in the `welcomeCommunity` field of the `config.yaml`.

Right now, this notification is sent only a minute after a user signs up, but that value is used for testing purposes.