### PR TITLE
Announcement notifications

### DIFF
--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -85,7 +85,15 @@ func serve(ctx *cli.Context) error {
 		return err
 	}, time.Minute, false)
 	tr.New("Send announcement notifications", func(ctx context.Context) error {
-		return core.SendAnnouncementNotifications(ctx, db, uid.ID{})
+		t0 := time.Now()
+		if err := core.SendAnnouncementNotifications(ctx, db, uid.ID{}); err != nil {
+			return err
+		}
+		took := time.Since(t0)
+		if took > time.Millisecond*100 {
+			log.Printf("Took %v to send announcement notifications\n", time.Since(t0))
+		}
+		return nil
 	}, time.Second*10, false)
 
 	go func() {

--- a/cli/serve/serve.go
+++ b/cli/serve/serve.go
@@ -84,6 +84,9 @@ func serve(ctx *cli.Context) error {
 		}
 		return err
 	}, time.Minute, false)
+	tr.New("Send announcement notifications", func(ctx context.Context) error {
+		return core.SendAnnouncementNotifications(ctx, db, uid.ID{})
+	}, time.Second*10, false)
 
 	go func() {
 		time.Sleep(time.Second * 2)

--- a/core/notification.go
+++ b/core/notification.go
@@ -1085,6 +1085,10 @@ func sendAnnouncementNotifications(ctx context.Context, db *sql.DB, post uid.ID)
 		return nil
 	}
 
+	if _, err := db.ExecContext(ctx, "UPDATE announcement_posts SET sending_started_at = ? WHERE post_id = ?", time.Now(), post); err != nil {
+		return err
+	}
+
 	sent := 0
 	for _, user := range users {
 		var rowID int

--- a/core/notification.go
+++ b/core/notification.go
@@ -1132,11 +1132,6 @@ func sendAnnouncementNotifications(ctx context.Context, db *sql.DB, post uid.ID)
 // not be one that expires quickly (such as a context gotten from
 // [http.Request]).
 func SendAnnouncementNotifications(ctx context.Context, db *sql.DB, post uid.ID) error {
-	t0 := time.Now()
-	defer func() {
-		log.Printf("Took %v to send announcement notifications\n", time.Since(t0))
-	}()
-
 	rows, err := db.QueryContext(ctx, "SELECT post_id FROM announcement_posts WHERE sending_finished_at IS NULL")
 	if err != nil {
 		return err

--- a/core/notification.go
+++ b/core/notification.go
@@ -239,7 +239,6 @@ func CreateNotification(ctx context.Context, db *sql.DB, user uid.ID, Type Notif
 	}
 
 	sendPushNotif := func() {
-		return
 		notif, err := GetNotification(ctx, db, strconv.Itoa(int(lastID)))
 		if err != nil {
 			log.Println("Error getting notification (CreateNotification)", err)

--- a/core/notification.go
+++ b/core/notification.go
@@ -48,6 +48,7 @@ const (
 	NotificationTypeModAdd       = NotificationType("mod_add")
 	NotificationTypeNewBadge     = NotificationType("new_badge")
 	NotificationTypeWelcome      = NotificationType("welcome")
+	NotificationTypeAnnouncement = NotificationType("announcement")
 )
 
 func (t NotificationType) Valid() bool {
@@ -59,6 +60,7 @@ func (t NotificationType) Valid() bool {
 		NotificationTypeModAdd,
 		NotificationTypeNewBadge,
 		NotificationTypeWelcome,
+		NotificationTypeAnnouncement,
 	}, t)
 }
 
@@ -162,6 +164,8 @@ func scanNotifications(db *sql.DB, rows *sql.Rows) ([]*Notification, error) {
 			nc = &NotificationNewBadge{}
 		case NotificationTypeWelcome:
 			nc = &NotificationWelcome{}
+		case NotificationTypeAnnouncement:
+			nc = &NotificationAnnouncement{}
 		default:
 			return nil, fmt.Errorf("unknown notification type: %s", string(notif.Type))
 		}
@@ -235,6 +239,7 @@ func CreateNotification(ctx context.Context, db *sql.DB, user uid.ID, Type Notif
 	}
 
 	sendPushNotif := func() {
+		return
 		notif, err := GetNotification(ctx, db, strconv.Itoa(int(lastID)))
 		if err != nil {
 			log.Println("Error getting notification (CreateNotification)", err)
@@ -1011,4 +1016,150 @@ func SendWelcomeNotifications(ctx context.Context, db *sql.DB, community string,
 	}
 
 	return success, nil
+}
+
+type NotificationAnnouncement struct {
+	PostID uid.ID `json:"postId"`
+}
+
+func (n *NotificationAnnouncement) marshalJSONForAPI(ctx context.Context, db *sql.DB) ([]byte, error) {
+	type T NotificationAnnouncement
+	out := struct {
+		T
+		Post      *Post      `json:"post"`
+		Community *Community `json:"community"`
+	}{T: (T)(*n)}
+
+	post, err := GetPost(ctx, db, &n.PostID, "", nil, true)
+	if err != nil {
+		return nil, err
+	}
+	community, err := GetCommunityByID(ctx, db, post.CommunityID, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	out.Post = post
+	out.Community = community
+	return json.Marshal(out)
+}
+
+// createAnnouncementNotifications creates (that is, sends) an announcement
+// notification of post to one user. If the user has more than one announcement
+// post already when this function is called, all those notifications except one
+// are deleted.
+func createAnnouncementNotification(ctx context.Context, db *sql.DB, post, receiver uid.ID) error {
+	// Select last 10 notifications to see if an identical notification exists.
+	notifs, _, err := GetNotifications(ctx, db, receiver, 10, "")
+	if err != nil {
+		return err
+	}
+	var unseen []*Notification
+	for _, notif := range notifs {
+		if notif.Type == NotificationTypeAnnouncement && !notif.Seen {
+			unseen = append(unseen, notif)
+		}
+	}
+	// There shouldn't be a ton of announcement notifications in the inbox, if,
+	// for instance, the user hasn't logged on for a while. So, delete all
+	// announcement notifications except one.
+	if len(unseen) > 1 {
+		for _, notif := range unseen[1:] {
+			if err := notif.Delete(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return CreateNotification(ctx, db, receiver, NotificationTypeAnnouncement, &NotificationAnnouncement{
+		PostID: post,
+	})
+}
+
+// sendAnnouncementNotifications sends an announcement notification of post to
+// every user account (except for the deleted and banned ones). This is an
+// expensive function that might take many seconds or minutes, depending on the
+// size of the userbase, to turn.
+func sendAnnouncementNotifications(ctx context.Context, db *sql.DB, post uid.ID) error {
+	users, err := GetAllUserIDs(ctx, db, false, false)
+	if err != nil {
+		return nil
+	}
+
+	sent := 0
+	for _, user := range users {
+		var rowID int
+		if err := db.QueryRowContext(ctx, "SELECT id FROM announcement_notifications_sent WHERE post_id = ? AND user_id = ?", post, user).Scan(&rowID); err != nil {
+			if err != sql.ErrNoRows {
+				return err
+			}
+		} else {
+			// Notification is already sent. Continue to the next user.
+			sent++
+			continue
+		}
+
+		if _, err := db.ExecContext(ctx, "INSERT INTO announcement_notifications_sent (post_id, user_id) VALUES (?, ?)", post, user); err != nil {
+			return err
+		}
+
+		// Send the notification
+		if err := createAnnouncementNotification(ctx, db, post, user); err != nil {
+			return err
+		}
+
+		sent++
+		if sent%50 == 0 {
+			// For every 50 notifs sent update the total_sent count.
+			db.ExecContext(ctx, "UPDATE announcement_posts SET total_sent = ? WHERE post_id = ?", sent, post)
+		}
+	}
+
+	totalSent := 0
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM announcement_notifications_sent WHERE post_id = ?", post).Scan(&totalSent); err != nil {
+		return err
+	}
+
+	if _, err := db.ExecContext(ctx, "UPDATE announcement_posts SET sending_finished_at = ?, total_sent = ? WHERE post_id = ?", time.Now(), totalSent, post); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendAnnouncementNotifications checks if any announcement notifications for
+// any posts needs to be sent, and if so, it sends all of them. Since this
+// function can take many seconds to minutes to run, the provided context should
+// not be one that expires quickly (such as a context gotten from
+// [http.Request]).
+func SendAnnouncementNotifications(ctx context.Context, db *sql.DB, post uid.ID) error {
+	t0 := time.Now()
+	defer func() {
+		log.Printf("Took %v to send announcement notifications\n", time.Since(t0))
+	}()
+
+	rows, err := db.QueryContext(ctx, "SELECT post_id FROM announcement_posts WHERE sending_finished_at IS NULL")
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var posts []uid.ID
+	for rows.Next() {
+		var post uid.ID
+		if err := rows.Scan(&post); err != nil {
+			return err
+		}
+		posts = append(posts, post)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	for _, post := range posts {
+		if err := sendAnnouncementNotifications(ctx, db, post); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/migrations/0049_announcement_posts_table.down.sql
+++ b/migrations/0049_announcement_posts_table.down.sql
@@ -1,0 +1,2 @@
+drop table announcement_posts;
+drop table announcement_notifications_sent;

--- a/migrations/0049_announcement_posts_table.up.sql
+++ b/migrations/0049_announcement_posts_table.up.sql
@@ -2,7 +2,7 @@ create table if not exists announcement_posts (
 	id int not null auto_increment,
 	post_id binary (12) not null,
 	announced_by binary (12) not null, 
-	sending_started_at datetime not null default current_timestamp(),
+	sending_started_at datetime,
 	sending_finished_at datetime,
 	total_sent int not null default 0,
 

--- a/migrations/0049_announcement_posts_table.up.sql
+++ b/migrations/0049_announcement_posts_table.up.sql
@@ -1,0 +1,25 @@
+create table if not exists announcement_posts (
+	id int not null auto_increment,
+	post_id binary (12) not null,
+	announced_by binary (12) not null, 
+	sending_started_at datetime not null default current_timestamp(),
+	sending_finished_at datetime,
+	total_sent int not null default 0,
+
+	primary key (id),
+	foreign key (post_id) references posts (id),
+	foreign key (announced_by) references users (id),
+	unique (post_id)
+);
+
+create table if not exists announcement_notifications_sent (
+	id int not null auto_increment,
+	post_id binary (12) not null,
+	user_id binary (12) not null,
+	sent_at datetime not null default current_timestamp(),
+
+	primary key (id),
+	foreign key (post_id) references posts (id),
+	foreign key (user_id) references users (id),
+	unique (post_id, user_id)
+);

--- a/server/post.go
+++ b/server/post.go
@@ -194,6 +194,10 @@ func (s *Server) updatePost(w *responseWriter, r *request) error {
 			if err = post.Pin(r.ctx, *r.viewer, siteWide, action == "unpin", false); err != nil {
 				return err
 			}
+		case "announce":
+			if err := post.AnnounceToAllUsers(r.ctx, *r.viewer); err != nil {
+				return err
+			}
 		default:
 			return httperr.NewBadRequest("invalid_action", "Unsupported action.")
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -96,8 +96,10 @@ func New(db *sql.DB, conf *config.Config) (*Server, error) {
 	if keys, err := core.GetApplicationVAPIDKeys(context.Background(), db); err != nil {
 		log.Printf("Error generating vapid keys: %v (you might want to run migrations)\n", err)
 	} else {
-		s.webPushVAPIDKeys = *keys
-		core.EnablePushNotifications(keys, "discuit@previnder.com")
+		if !conf.IsDevelopment {
+			s.webPushVAPIDKeys = *keys
+			core.EnablePushNotifications(keys, "discuit@previnder.com")
+		}
 	}
 
 	s.openLoggers()

--- a/ui/src/components/Navbar/notification.ts
+++ b/ui/src/components/Navbar/notification.ts
@@ -4,6 +4,7 @@ import { badgeImage } from '../../pages/User/badgeImage';
 import {
   Community,
   Notification,
+  NotificationAnnouncement,
   NotificationCommentReply,
   NotificationModAdd,
   NotificationNewBadge,
@@ -140,6 +141,14 @@ export function getNotificationDisplayInformation(
         const notif = notification.notif as NotificationWelcome;
         text = `${tag('<b>')}Welcome to Discuit${tag('</b>')} Make a post in our ${tag('<b>')}${notif.community.name}${tag('</b>')} community to say hello!`;
         to = `/${notif.community.name}`;
+        image = getNotifImage(notif);
+      }
+      break;
+    case 'announcement':
+      {
+        const notif = notification.notif as NotificationAnnouncement;
+        text = `${tag('<b>') + notif.post.title + tag('</b>')}`;
+        to = `/${notif.post.communityName}/post/${notif.post.publicId}`;
         image = getNotifImage(notif);
       }
       break;

--- a/ui/src/pages/Post/index.jsx
+++ b/ui/src/pages/Post/index.jsx
@@ -238,6 +238,24 @@ const Post = () => {
     })();
   };
 
+  const handleAnnounce = async () => {
+    if (!confirm('Are you sure? This will send a notification to all users.')) {
+      return;
+    }
+    try {
+      const res = await mfetch(`/api/posts/${post.publicId}?action=announce`, { method: 'PUT' });
+      if (!res.ok) {
+        if (res.status === 409) {
+          dispatch(snackAlert('Already announced'));
+        } else {
+          throw new Error(await res.text());
+        }
+      }
+    } catch (error) {
+      dispatch(snackAlertError(error));
+    }
+  };
+
   const isMobile = useIsMobile();
   const loggedIn = user !== null;
   const isAdmin = loggedIn && user.isAdmin;
@@ -532,6 +550,9 @@ const Post = () => {
                           <label htmlFor={'ch-pin-a'}>Pinned</label>
                         </div>
                       </div>
+                      <button className="button-clear dropdown-item" onClick={handleAnnounce}>
+                        Announce
+                      </button>
                     </div>
                   </Dropdown>
                 )}

--- a/ui/src/serverTypes.ts
+++ b/ui/src/serverTypes.ts
@@ -197,7 +197,8 @@ export type NotificationType =
   | 'deleted_post'
   | 'mod_add'
   | 'new_badge'
-  | 'welcome';
+  | 'welcome'
+  | 'announcement';
 
 export interface Notification {
   id: number;
@@ -210,7 +211,8 @@ export interface Notification {
     | NotificationPostDeleted
     | NotificationModAdd
     | NotificationNewBadge
-    | NotificationWelcome;
+    | NotificationWelcome
+    | NotificationAnnouncement;
   seen: boolean;
   seenAt: string | null; // A datetime.
   createdAt: string; // A datetime.
@@ -264,6 +266,12 @@ export interface NotificationNewBadge {
 
 export interface NotificationWelcome {
   communityName: string;
+  community: Community;
+}
+
+export interface NotificationAnnouncement {
+  postId: string;
+  post: Post;
   community: Community;
 }
 


### PR DESCRIPTION
Introduces a new notification type to let all the users know of new announcements on the site; essentially, by sending a notification for the announcement post to all the users.

While working on this, however, it occurred to me how the notification rendering currently works—that is, on the front-end, using the structured objects returned from the server—is not ideal, especially for a site that uses the Web Push API for native notifications. The reason being that, in the current system, when a new notification type is introduced, the `service-worker.js` needs to be updated for the users to get the new notification via the Web Push API; and that that updating doesn't happen—and there's no way to make it happen—until the user visits the site. If the notification was rendered in a standard form on the server, however, this issue wouldn't arise, as in that case there wouldn't be notification types.