### PR TITLE
Fix a couple of hard-to-interpret error messages

### DIFF
--- a/ui/src/pages/NewPost/index.jsx
+++ b/ui/src/pages/NewPost/index.jsx
@@ -244,7 +244,7 @@ const NewPost = () => {
         if (!res.ok) {
           if (res.status === 400) {
             const error = await res.json();
-            if (error.code === 'invalid_url') {
+            if (error.code === 'invalid-url') {
               dispatch(snackAlert('The URL you provided is not a valid URL.'));
               return;
             }

--- a/ui/src/pages/Post/index.jsx
+++ b/ui/src/pages/Post/index.jsx
@@ -219,13 +219,11 @@ const Post = () => {
         );
         if (!res.ok) {
           let handledError = false;
-          if (res.status === 400) {
+          if (res.status === 403) {
             const error = await res.json();
-            if (error.code === 'max_pinned_count_reached') {
-              dispatch(snackAlert('Max pinned posts count reached.'));
-              set(checkedBefore);
-              handledError = true;
-            }
+            dispatch(snackAlert(error.message));
+            set(checkedBefore);
+            handledError = true;
           }
           if (!handledError) {
             throw new Error(await res.text());


### PR DESCRIPTION
Fixed a couple of error messages that the front-end was not reporting properly.

Closes #54 (inscrutable message when providing an invalid URL for a link post) and additionally alerts the user when they exceed the number of disc/site pins.

I've made the minimal changes above and it seems to work, but how the front-end error alerts are handled is somewhat confusing to me. In [/ui/src/pages/NewPost/index.jsx](https://github.com/discuitnet/discuit/blob/11f7aa653f0925b79038ccc16a2a7648d4cc2234/ui/src/pages/NewPost/index.jsx#L130), I see this:

```
        if (!res.ok) {
          if (res.status === 400) {
            const error = await res.json();
            if (error.code === 'file_size_exceeded') {
              dispatch(snackAlert('Maximum file size exceeded.'));
              return;
            } else if (error.code === 'unsupported_image') {
              dispatch(snackAlert('Unsupported image.'));
              return;
            }
          }
          throw new APIError(res.status, await res.json());
        }
```

I feel like it should be using the `error.message` provided by the back-end to print out the alert text, in which case it doesn't need to do if/else switching on `error.code`. And if the back-end doesn't provide a usable error object, then it would fall into the `throw new APIError` code to be caught later. If my thinking's correct, I can spend some time making the messaging more consistent over the rest of the front-end.