### PR TITLE
add preference to require alt text when posting

### DIFF
--- a/core/user.go
+++ b/core/user.go
@@ -129,6 +129,7 @@ type User struct {
 	RememberFeedSort        bool     `json:"rememberFeedSort"`
 	EmbedsOff               bool     `json:"embedsOff"`
 	HideUserProfilePictures bool     `json:"hideUserProfilePictures"`
+	RequireAltText bool `json:"requireAltText"`
 
 	WelcomeNotificationSent bool `json:"-"`
 
@@ -246,6 +247,7 @@ func buildSelectUserQuery(where string) string {
 		"users.embeds_off",
 		"users.hide_user_profile_pictures",
 		"users.welcome_notification_sent",
+		"users.require_alt_text",
 	}
 	cols = append(cols, images.ImageColumns("pro_pic")...)
 	joins := []string{
@@ -348,6 +350,7 @@ func scanUsers(ctx context.Context, db *sql.DB, rows *sql.Rows, viewer *uid.ID) 
 			&u.EmbedsOff,
 			&u.HideUserProfilePictures,
 			&u.WelcomeNotificationSent,
+			&u.RequireAltText,
 		}
 
 		proPic := &images.Image{}
@@ -635,7 +638,8 @@ func (u *User) Update(ctx context.Context, db *sql.DB) error {
 		home_feed = ?,
 		remember_feed_sort = ?,
 		embeds_off = ?,
-		hide_user_profile_pictures = ?
+		hide_user_profile_pictures = ?,
+		require_alt_text = ?
 	WHERE id = ?`,
 		u.EmailPublic,
 		u.About,
@@ -645,6 +649,7 @@ func (u *User) Update(ctx context.Context, db *sql.DB) error {
 		u.RememberFeedSort,
 		u.EmbedsOff,
 		u.HideUserProfilePictures,
+		u.RequireAltText,
 		u.ID)
 	return err
 }

--- a/core/user.go
+++ b/core/user.go
@@ -129,7 +129,7 @@ type User struct {
 	RememberFeedSort        bool     `json:"rememberFeedSort"`
 	EmbedsOff               bool     `json:"embedsOff"`
 	HideUserProfilePictures bool     `json:"hideUserProfilePictures"`
-	RequireAltText bool `json:"requireAltText"`
+	RequireAltText          bool     `json:"requireAltText"`
 
 	WelcomeNotificationSent bool `json:"-"`
 

--- a/migrations/0054_require_alt_text_user_config.down.sql
+++ b/migrations/0054_require_alt_text_user_config.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+DROP COLUMN require_alt_text;

--- a/migrations/0054_require_alt_text_user_config.down.sql
+++ b/migrations/0054_require_alt_text_user_config.down.sql
@@ -1,2 +1,1 @@
-ALTER TABLE users
-DROP COLUMN require_alt_text;
+ALTER TABLE users DROP COLUMN require_alt_text;

--- a/migrations/0054_require_alt_text_user_config.up.sql
+++ b/migrations/0054_require_alt_text_user_config.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE users
+ADD COLUMN require_alt_text bool NOT NULL DEFAULT false;
+
+ALTER TABLE users ADD INDEX idx_require_alt_text (require_alt_text);

--- a/migrations/0054_require_alt_text_user_config.up.sql
+++ b/migrations/0054_require_alt_text_user_config.up.sql
@@ -1,4 +1,1 @@
-ALTER TABLE users
-ADD COLUMN require_alt_text bool NOT NULL DEFAULT false;
-
-ALTER TABLE users ADD INDEX idx_require_alt_text (require_alt_text);
+ALTER TABLE users ADD COLUMN require_alt_text bool NOT NULL DEFAULT false;

--- a/ui/src/pages/NewPost/Image.tsx
+++ b/ui/src/pages/NewPost/Image.tsx
@@ -9,10 +9,17 @@ export interface ImageProps {
   image: ServerImage;
   onClose: () => void;
   disabled?: boolean;
+  requiresAltText: boolean;
   onAltTextSave: (altText: string) => void;
 }
 
-const Image = ({ image, onClose, disabled = false, onAltTextSave }: ImageProps) => {
+const Image = ({
+  image,
+  onClose,
+  disabled = false,
+  requiresAltText,
+  onAltTextSave,
+}: ImageProps) => {
   const { width, height } = image;
   const windowWidth = useWindowWidth();
 
@@ -31,6 +38,8 @@ const Image = ({ image, onClose, disabled = false, onAltTextSave }: ImageProps) 
     imgHeight = Math.floor(scale * height);
 
   const [altText, setAltText] = useState(image.altText || '');
+  const missingAltText = requiresAltText ? altText.trim().length <= 0 : false;
+
   useEffect(() => {
     setAltText(image.altText || '');
   }, [image.altText]);
@@ -58,8 +67,8 @@ const Image = ({ image, onClose, disabled = false, onAltTextSave }: ImageProps) 
       {/* alt text input */}
       {!disabled && (
         <Textarea
-          className="page-new-image-alt"
-          placeholder="Describe this image (alt text)…"
+          className={`page-new-image-alt${missingAltText ? ' is-error' : ''}`}
+          placeholder={'Describe this image (alt text)…'}
           value={altText}
           onChange={(e) => setAltText(e.target.value)}
           onBlur={() => {

--- a/ui/src/pages/NewPost/Image.tsx
+++ b/ui/src/pages/NewPost/Image.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { ButtonClose } from '../../components/Button';
 import Img from '../../components/Image';
@@ -67,7 +68,7 @@ const Image = ({
       {/* alt text input */}
       {!disabled && (
         <Textarea
-          className={`page-new-image-alt${missingAltText ? ' is-error' : ''}`}
+          className={clsx('page-new-image-alt', missingAltText && 'is-error')}
           placeholder={'Describe this image (alt text)…'}
           value={altText}
           onChange={(e) => setAltText(e.target.value)}

--- a/ui/src/pages/NewPost/index.tsx
+++ b/ui/src/pages/NewPost/index.tsx
@@ -186,11 +186,12 @@ const NewPost = () => {
     }
   };
 
-  const missingAlt =
-    user.requireAltText && images.some((img) => !img.altText || img.altText.trim() === '');
+  const isAltMissing = () => {
+    return user.requireAltText && images.some((img) => !img.altText || img.altText.trim() === '');
+  };
 
   const [_isSubmitDisabled, setIsSubmitting] = useState(false);
-  const isSubmitDisabled = _isSubmitDisabled || isUploading || isPostingDisabled || missingAlt;
+  const isSubmitDisabled = _isSubmitDisabled || isUploading || isPostingDisabled || isAltMissing();
   const handleSubmit = async () => {
     if (isSubmitDisabled) return;
     if (isBanned) {
@@ -215,8 +216,7 @@ const NewPost = () => {
         return;
       }
       if (user.requireAltText) {
-        const missingAlt = images.some((img) => !img.altText || img.altText.trim() === '');
-        if (missingAlt) {
+        if (isAltMissing()) {
           alert(
             "One or more images are missing alt text. Please make sure that you've added alt text to all images."
           );

--- a/ui/src/pages/NewPost/index.tsx
+++ b/ui/src/pages/NewPost/index.tsx
@@ -186,8 +186,11 @@ const NewPost = () => {
     }
   };
 
+  const missingAlt =
+    user.requireAltText && images.some((img) => !img.altText || img.altText.trim() === '');
+
   const [_isSubmitDisabled, setIsSubmitting] = useState(false);
-  const isSubmitDisabled = _isSubmitDisabled || isUploading || isPostingDisabled;
+  const isSubmitDisabled = _isSubmitDisabled || isUploading || isPostingDisabled || missingAlt;
   const handleSubmit = async () => {
     if (isSubmitDisabled) return;
     if (isBanned) {
@@ -210,6 +213,15 @@ const NewPost = () => {
       if (images.length === 0) {
         alert("You haven't uploaded an image");
         return;
+      }
+      if (user.requireAltText) {
+        const missingAlt = images.some((img) => !img.altText || img.altText.trim() === '');
+        if (missingAlt) {
+          alert(
+            "One or more images are missing alt text. Please make sure that you've added alt text to all images."
+          );
+          return;
+        }
       }
     }
     if (postType === 'link') {
@@ -499,6 +511,7 @@ const NewPost = () => {
                           body: JSON.stringify({ altText }),
                         });
                       }}
+                      requiresAltText={user.requireAltText}
                     />
                   ))}
                 {!isEditPost && !(post && post.deletedContent) && (

--- a/ui/src/pages/Settings/index.tsx
+++ b/ui/src/pages/Settings/index.tsx
@@ -382,7 +382,7 @@ const Settings = () => {
           <FormField className="is-preference is-switch">
             <Checkbox
               variant="switch"
-              label="Require alt text when posting"
+              label="Require alt text when posting images"
               checked={requireAltText}
               onChange={(e) => setRequireAltText(e.target.checked)}
             />

--- a/ui/src/pages/Settings/index.tsx
+++ b/ui/src/pages/Settings/index.tsx
@@ -64,6 +64,7 @@ const Settings = () => {
   const [showUserProfilePictures, setShowUserProfilePictures] = useState(
     !user.hideUserProfilePictures
   );
+  const [requireAltText, setRequireAltText] = useState(user.requireAltText);
 
   const fontOptions = {
     custom: 'Custom', // value -> display name
@@ -88,6 +89,7 @@ const Settings = () => {
     showUserProfilePictures,
     font,
     infiniteScrollingDisabed,
+    requireAltText,
   ]);
 
   const applicationServerKey = useSelector<RootState>(
@@ -150,6 +152,7 @@ const Settings = () => {
           embedsOff: !enableEmbeds,
           email,
           hideUserProfilePictures: !showUserProfilePictures,
+          requireAltText,
         }),
       });
       dispatch(userLoggedIn(ruser));
@@ -374,6 +377,14 @@ const Settings = () => {
               label="Show user profile pictures"
               checked={showUserProfilePictures}
               onChange={(e) => setShowUserProfilePictures(e.target.checked)}
+            />
+          </FormField>
+          <FormField className="is-preference is-switch">
+            <Checkbox
+              variant="switch"
+              label="Require alt text when posting"
+              checked={requireAltText}
+              onChange={(e) => setRequireAltText(e.target.checked)}
             />
           </FormField>
         </FormSection>

--- a/ui/src/serverTypes.ts
+++ b/ui/src/serverTypes.ts
@@ -20,6 +20,7 @@ export interface User {
   rememberFeedSort: boolean;
   embedsOff: boolean;
   hideUserProfilePictures: boolean;
+  requireAltText: boolean;
   bannedAt: string | null; // A datetime.
   isBanned: boolean;
   notificationsNewCount: number;


### PR DESCRIPTION
adds a new user preference to require adding alt text to images before posting. this is **not** set locally & adds a new field, `require_alt_text`, to the `users` table. this is `false` by default. 

it's just a nice qol thing that helps you... *forces you* to remember to add alt text if you want it. 

if the option is enabled & an image doesn't have alt text, the alt text box will be outlined red and the "submit" button will be disabled. preview:

![the discuit "new post" page with two images added, the first image has alt text while the second doesn't, and has a red outline.](https://github.com/user-attachments/assets/c7193dec-4fd7-4cd0-b63b-43fb7f215d2f)
