### PR TITLE
Tweak some admin endpoints

### DIFF
--- a/core/community.go
+++ b/core/community.go
@@ -1344,7 +1344,7 @@ func GetCommunityRequests(ctx context.Context, db *sql.DB) ([]*CommunityRequest,
 		SELECT cr.id, cr.by_user, cr.community_name, cr.note, cr.created_at, c.id IS NOT NULL, cr.denied_note, cr.denied_by, cr.denied_at
 		FROM community_requests AS cr 
 		LEFT JOIN communities AS c ON cr.community_name_lc = c.name_lc 
-		WHERE cr.created_at >  SUBDATE(NOW(), 90)
+		WHERE cr.created_at >  SUBDATE(NOW(), 90) AND cr.deleted_at IS NULL
 		ORDER BY created_at DESC`,
 	)
 	if err != nil {

--- a/core/user.go
+++ b/core/user.go
@@ -104,6 +104,11 @@ type User struct {
 
 	EmailPublic *string `json:"email"`
 
+	// Additional admin-only viewable fields
+	LastSeenPublic   *time.Time `json:"lastSeen,omitempty"`
+	LastSeenIPPublic *string    `json:"lastSeenIP,omitempty"`
+	CreatedIPPublic  *string    `json:"createdIP,omitempty"`
+
 	Email            msql.NullString `json:"-"`
 	EmailConfirmedAt msql.NullTime   `json:"emailConfirmedAt"`
 	Password         string          `json:"-"`
@@ -419,6 +424,11 @@ func scanUsers(ctx context.Context, db *sql.DB, rows *sql.Rows, viewer *uid.ID) 
 				user.EmailPublic = new(string)
 				*user.EmailPublic = user.Email.String
 			}
+		}
+		if viewerAdmin {
+			user.LastSeenPublic = &user.LastSeen
+			user.LastSeenIPPublic = user.LastSeenIP
+			user.CreatedIPPublic = user.CreatedIP
 		}
 		// Set the user info of deleted users to the ghost user for everyone
 		// except the admins.
@@ -1425,7 +1435,7 @@ func GetUsers(ctx context.Context, db *sql.DB, limit int, next *string, viewer *
 	if next != nil {
 		nextID, err := uid.FromString(*next)
 		if err != nil {
-			return nil, nil, errors.New("invalid next for site comments")
+			return nil, nil, errors.New("invalid next for site users")
 		}
 		where = "WHERE users.id <= ? "
 		args = append(args, nextID)

--- a/server/server.go
+++ b/server/server.go
@@ -180,7 +180,7 @@ func New(db *sql.DB, conf *config.Config) (*Server, error) {
 
 	r.Handle("/api/community_requests", s.withHandler(s.createCommunityRequest)).Methods("POST")
 	r.Handle("/api/community_requests", s.withHandler(s.getCommunityRequests)).Methods("GET")
-	r.Handle("/api/community_requests/{requestID}", s.withHandler(s.deleteCommunityRequest)).Methods("DELTE")
+	r.Handle("/api/community_requests/{requestID}", s.withHandler(s.deleteCommunityRequest)).Methods("DELETE")
 
 	r.Handle("/api/_report", s.withHandler(s.report)).Methods("POST")
 


### PR DESCRIPTION
Mainly to move some data extraction of only-admin-readable fields into the `/api/users` endpoint. It is possible, but time-consuming, to extract the data of the relevant fields user-by-user ([via `adminsView`](https://github.com/discuitnet/discuit/blob/852a24ad62332de7fa39d16d833e40a95d9bbb98/server/user.go#L41)), and it makes more sense to make them available from `/api/users` since that is locked behind admins anyway. I believe this implementation in `scanUsers` should prevent leakage of the material for other users requesting data.

Additionally fixes a typo on the endpoint here ("DELTE"): `r.Handle("/api/community_requests/{requestID}", s.withHandler(s.deleteCommunityRequest)).Methods("DELTE")`

I've also added filtering to ignore deleted requests from the request extraction. Not sure if you prefer using this endpoint to mark disc requests as deleted rather than denied with logging as in #166. It seems otherwise unused. 
