### PR TITLE
fix not being able to add new rules via the ui 

### DIFF
--- a/ui/src/pages/Modtools/Rules.tsx
+++ b/ui/src/pages/Modtools/Rules.tsx
@@ -59,11 +59,9 @@ const Rules = ({ community }: { community: Community }) => {
   };
 
   const handleSave = async () => {
-    if (!ruleEditing) {
-      return;
-    }
     try {
       if (isEditRule) {
+        if (!ruleEditing) return;
         const rrule = await mfetchjson(`/api/communities/${community.id}/rules/${ruleEditing.id}`, {
           method: 'PUT',
           body: JSON.stringify({ zIndex: ruleEditing.zIndex, rule, description }),


### PR DESCRIPTION
i moved `if (!ruleEditing) return;` inside of the `if (isEditRule) { ... }` block, before it was at the top level of `handleSave`, and so would return when trying to add a new rule 