### PR TITLE
Ensure first image is representative image of image gallery posts

### DIFF
--- a/core/post.go
+++ b/core/post.go
@@ -530,6 +530,7 @@ func populatePostsImages(ctx context.Context, db *sql.DB, posts []*Post) error {
 		return err
 	}
 	defer rows.Close()
+	finishedPosts := []uid.ID{}
 
 	for rows.Next() {
 		record, postID := &images.ImageRecord{}, uid.ID{}
@@ -548,7 +549,10 @@ func populatePostsImages(ctx context.Context, db *sql.DB, posts []*Post) error {
 				img.AppendCopy("medium", 720, 1440, images.ImageFitContain, "")
 				img.AppendCopy("large", 1080, 2160, images.ImageFitContain, "")
 				img.AppendCopy("large", 2160, 4320, images.ImageFitContain, "")
-				post.Image = img
+				if !(slices.Contains(finishedPosts, post.ID)) {
+					post.Image = img
+					finishedPosts = append(finishedPosts, post.ID)
+				}
 				post.Images = append(post.Images, img)
 				break
 			}


### PR DESCRIPTION
[User @avirse reported on-site](https://discuit.org/DiscuitSuggestions/post/tg6gPYap) that compact mode was using the last image in a gallery as the link image. In [`populatePostsImages()`](https://github.com/discuitnet/discuit/blob/bee07282f5f1ff888de88df0a0cb0059993e75fd/core/post.go#L534), it seems like this is the result of `post.Image = img` being set every iteration of the loop. Therefore this behaviour should be fixed if `post.Image` is only set the first time the post is processed (assuming the post images are retrieved in order, which seems to be the case).

It seemed minimally invasive to use a slice to keep track of the post IDs which had been already seen and then subsequently skip the assignment, so that is how I implemented it.
