### PR TITLE
Add IP fields to admin dashboard user listing

### DIFF
--- a/ui/src/pages/AdminDashboard/Users.tsx
+++ b/ui/src/pages/AdminDashboard/Users.tsx
@@ -57,7 +57,7 @@ export default function Users() {
   const handleRenderItem = (item: User) => {
     const user = item;
     return (
-      <TableRow columns={3}>
+      <TableRow columns={5}>
         <Link className="table-column" to={`/@${user.username}`}>
           @{user.username}
         </Link>
@@ -65,16 +65,24 @@ export default function Users() {
           {user.isBanned ? 'Banned' : user.deleted ? 'Deleted' : ''}
         </div>
         <TimeAgo className="table-column" time={user.createdAt} />
+        <div className="table-column">
+          {user.createdIP}
+        </div>
+        <div className="table-column">
+          {user.lastSeenIP}
+        </div>
       </TableRow>
     );
   };
 
   const handleRenderHead = () => {
     return (
-      <TableRow columns={3} head>
+      <TableRow columns={5} head>
         <div className="table-column">Username</div>
         <div className="table-column">Deleted</div>
         <div className="table-column">Created at</div>
+        <div className="table-column">Created IP</div>
+        <div className="table-column">Last IP</div>
       </TableRow>
     );
   };

--- a/ui/src/serverTypes.ts
+++ b/ui/src/serverTypes.ts
@@ -25,6 +25,8 @@ export interface User {
   isBanned: boolean;
   notificationsNewCount: number;
   moddingList: Community[] | null;
+  createdIP: string | null;
+  lastSeenIP: string | null;
 }
 
 export type UserGroup = 'normal' | 'admins' | 'mods';


### PR DESCRIPTION
Adding IP addresses to admin dashboard as requested by one of the admins. I believe this does not further expose IPs to other elements of the site, since they ultimately get routed through an entirely different path to [`scanUsers()`](https://github.com/discuitnet/discuit/blob/bee07282f5f1ff888de88df0a0cb0059993e75fd/core/user.go#L344).