### PR TITLE
fix crash when `GET /api/_initial` times out 

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -93,11 +93,10 @@ const App = () => {
 
         if (!res.ok) {
           if (res.status === 408) {
-            // Network error
             setIsOnline(false);
-          } else {
-            throw new Error(await res.text());
+            return;
           }
+          throw new Error(await res.text());
         }
 
         const initial = await res.json();


### PR DESCRIPTION
issue reported [here](https://discuit.org/DiscuitDev/post/s4JnkOHR).

i just added a `return` statement :p otherwise, `initial` would go on to be set to `{ status: x, message: y }`, and that would be dispatched to the rest of the app instead of something of type `InitialValues` which is what `initialFieldsSet` expects.