### PR TITLE
Fix badly cropped images

### DIFF
--- a/core/post.go
+++ b/core/post.go
@@ -543,8 +543,8 @@ func populatePostsImages(ctx context.Context, db *sql.DB, posts []*Post) error {
 			if post.ID == postID {
 				img := record.Image()
 				img.PostScan()
-				img.AppendCopy("tiny", 120, 120, images.ImageFitCover, "")
-				img.AppendCopy("small", 325, 250, images.ImageFitCover, "")
+				img.AppendCopy("tiny", 120, 120, images.ImageFitContain, "")
+				img.AppendCopy("small", 325, 250, images.ImageFitContain, "")
 				img.AppendCopy("medium", 720, 1440, images.ImageFitContain, "")
 				img.AppendCopy("large", 1080, 2160, images.ImageFitContain, "")
 				img.AppendCopy("large", 2160, 4320, images.ImageFitContain, "")

--- a/ui/src/pages/NewPost/index.tsx
+++ b/ui/src/pages/NewPost/index.tsx
@@ -132,6 +132,7 @@ const NewPost = () => {
           body: data,
         });
         if (!res.ok) {
+          setIsUploading(false);
           if (res.status === 400) {
             const error = await res.json();
             if (error.code === 'file_size_exceeded') {
@@ -152,6 +153,7 @@ const NewPost = () => {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
           dispatch(snackAlertError(error));
         }
+        setIsUploading(false);
         break;
       }
     }


### PR DESCRIPTION
This PR swaps image copies to use "contain" rather than "cover" for smaller images and this should resolve the cropping issues noted in #72.

I also added cancellations of the uploading indicator to the image upload component, since uploading images past the 25 MB limit was showing the expected error message, but not unlocking the upload element.
