### PR TITLE
allow editing alt text after an image has been posted

### DIFF
--- a/ui/src/pages/NewPost/Image.tsx
+++ b/ui/src/pages/NewPost/Image.tsx
@@ -12,6 +12,7 @@ export interface ImageProps {
   disabled?: boolean;
   requiresAltText: boolean;
   onAltTextSave: (altText: string) => void;
+  isEditMode?: boolean;
 }
 
 const Image = ({
@@ -20,6 +21,7 @@ const Image = ({
   disabled = false,
   requiresAltText,
   onAltTextSave,
+  isEditMode = false,
 }: ImageProps) => {
   const { width, height } = image;
   const windowWidth = useWindowWidth();
@@ -66,7 +68,7 @@ const Image = ({
         />
       </div>
       {/* alt text input */}
-      {!disabled && (
+      {(!disabled || isEditMode) && (
         <Textarea
           className={clsx('page-new-image-alt', missingAltText && 'is-error')}
           placeholder={'Describe this image (alt text)…'}


### PR DESCRIPTION
some trivial changes

- added `altTextChanges` state to NewPost 
- added `isEditMode` prop to `NewPost/Image.tsx`, if it's true then text area for editing alt text will be shown
- when alt text is edited, the entry for that image in `altTextChanges` is updated 
- on submit, all changes in `altTextChanges` are send in parallel via `Promise.all `