### PR TITLE
Fix off-by-one error in post title validation.

### DIFF
--- a/ui/src/pages/NewPost/index.tsx
+++ b/ui/src/pages/NewPost/index.tsx
@@ -75,7 +75,7 @@ const NewPost = () => {
 
   const [title, _setTitle] = useState('');
   const setTitle = (title: string) =>
-    _setTitle(title.length > 255 ? title.substring(0, 256) : title);
+    _setTitle(title.length > 255 ? title.substring(0, 255) : title);
   const [body, setBody] = useState('');
   const [link, setLink] = useState('');
   const [images, SetImages] = useState<ServerImage[]>([]);


### PR DESCRIPTION
User reported confusion yesterday at the front-end allowing the full title, but [the back-end truncating](https://discuit.org/TodayILearned/post/TdSgspXy). Seems to be due to an off-by-one error.