### PR TITLE
Feed image width

### DIFF
--- a/ui/src/components/PostCard/PostCardImage.tsx
+++ b/ui/src/components/PostCard/PostCardImage.tsx
@@ -22,7 +22,7 @@ const PostCardImage = ({ image, isMobile, loading = 'lazy' }: ImageProps) => {
   const w = document.querySelector('.post-card-body')?.clientWidth as number;
   const updateImageSize = useCallback(() => {
     const h = isMobile ? maxImageHeightMobile() : maxImageHeight;
-    let { width, height } = getImageContainSize(image.width, image.height, w, h);
+    const { width, height } = getImageContainSize(image.width, image.height, w, h);
     setCardWidth(w);
     setImageSize({ width, height });
   }, [image.height, image.width, isMobile, w]);


### PR DESCRIPTION
The code in the `PostImage` component that allows for slight obscuring of the image has some degenerate arithmetic. [See this video here](https://www.youtube.com/watch?v=m9RzHq5AAxc), which shows the image initially loads cropped, and then repeated resizing of the window alternates between fully displaying and cropping, until the arithmetic eventually sets the image to a compatible size. The corners also vary between rounded and not rounded. I think the code allowing cropping should be removed for a more consistent experience, and adding a dependence to the card width will properly apply the corner rounding.
