### PR TITLE
Fix double PFPs and hung uploads on errors

### DIFF
--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -77,8 +77,8 @@ export function useInputUsername(
 export function useWindowSize() {
   const getSize = () => {
     return {
-      width: document.documentElement.clientWidth,
-      height: document.documentElement.clientHeight,
+      width: window.innerWidth,
+      height: window.innerHeight,
     };
   };
   const [size, setSize] = useState(getSize());

--- a/ui/src/pages/NewPost/index.tsx
+++ b/ui/src/pages/NewPost/index.tsx
@@ -132,6 +132,7 @@ const NewPost = () => {
           body: data,
         });
         if (!res.ok) {
+          setIsUploading(false);
           if (res.status === 400) {
             const error = await res.json();
             if (error.code === 'file_size_exceeded') {
@@ -152,6 +153,7 @@ const NewPost = () => {
         if (!(error instanceof DOMException && error.name === 'AbortError')) {
           dispatch(snackAlertError(error));
         }
+        setIsUploading(false);
         break;
       }
     }


### PR DESCRIPTION
Closes #178. Additionally prevents the image upload component from hanging when there is an error. This was missed when #175 was declined due to introducing a separate problem.