### PR TITLE
UI: Move gallery indicators/controls below image

### DIFF
--- a/ui/src/components/ImageGallery.tsx
+++ b/ui/src/components/ImageGallery.tsx
@@ -61,10 +61,8 @@ export default function ImageGallery({
     const dots = [];
     for (let i = 0; i < numImages; i++) {
       dots.push(
-        //(currentImageIndex !== i ? <div className='image-gallery-dot' key = {`dot-${i}`}></div> : <div>{i + 1}</div>)
-        
         <div
-          className={'image-gallery-' + (currentImageIndex === i ? 'num is-highlighted' : 'dot')}
+          className={'image-gallery-' + (currentImageIndex === i ? 'num' : 'dot')}
           key={`dot-${i}`}
         >{(currentImageIndex === i ? i + 1 : '')}</div>
       );

--- a/ui/src/components/ImageGallery.tsx
+++ b/ui/src/components/ImageGallery.tsx
@@ -61,10 +61,12 @@ export default function ImageGallery({
     const dots = [];
     for (let i = 0; i < numImages; i++) {
       dots.push(
+        //(currentImageIndex !== i ? <div className='image-gallery-dot' key = {`dot-${i}`}></div> : <div>{i + 1}</div>)
+        
         <div
-          className={'image-gallery-dot' + (currentImageIndex === i ? ' is-highlighted' : '')}
+          className={'image-gallery-' + (currentImageIndex === i ? 'num is-highlighted' : 'dot')}
           key={`dot-${i}`}
-        ></div>
+        >{(currentImageIndex === i ? i + 1 : '')}</div>
       );
     }
     return <div className="image-gallery-dots">{dots}</div>;
@@ -102,21 +104,26 @@ export default function ImageGallery({
   }, [showLeftArrow, showRightArrow, keyboardControlsOn]);
 
   return (
-    <div className={'image-gallery' + (className ? ` ${className}` : '')} {...props}>
-      <div
-        className="image-gallery-next-btn is-button is-previous"
-        onClick={() => setCurrentImageIndex(showLeftArrow ? (n) => n - 1 : numImages - 1)}
-      >
-        {nextIcon}
+    <>
+      <div className={'image-gallery' + (className ? ` ${className}` : '')} {...props}>
+        {renderImages()}
       </div>
-      <div
-        className="image-gallery-next-btn is-button"
-        onClick={() => setCurrentImageIndex(showRightArrow ? (n) => n + 1 : 0)}
-      >
-        {nextIcon}
+      <div className='image-gallery-gutter'>
+        <div
+          className="image-gallery-next-btn is-button is-previous"
+          onClick={() => setCurrentImageIndex(showLeftArrow ? (n) => n - 1 : numImages - 1)}
+        >
+          {nextIcon}
+        </div>
+        {renderDots()}
+        <div
+          className="image-gallery-next-btn is-button"
+          onClick={() => setCurrentImageIndex(showRightArrow ? (n) => n + 1 : 0)}
+        >
+          {nextIcon}
+        </div>
       </div>
-      {renderImages()}
-      {renderDots()}
-    </div>
+    </>
+
   );
 }

--- a/ui/src/scss/_components.scss
+++ b/ui/src/scss/_components.scss
@@ -1151,15 +1151,17 @@
     }
 }
 
-.image-gallery {
-    position: relative;
-
+.image-gallery-gutter {
     // Without this, Chrome, for some reason, automatically selects the images
     // when clicking on the next and previous buttons quickly.
     user-select: none;
+    position: relative;
+    height: fit-content;
+    display: flex;
+    justify-content: space-between;
 
     .image-gallery-next-btn {
-        position: absolute;
+        position: relative;
         z-index: 100;
         cursor: pointer;
         right: 0;
@@ -1184,6 +1186,48 @@
             filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
         }
     }
+
+    .image-gallery-dots {
+        position: relative;
+        z-index: 100;
+        top: 50%;
+        display: flex;
+        .image-gallery-dot {
+            position: relative;
+            --size: 6px;
+            top:calc(1.5 * var(--size));
+            width: var(--size);
+            height: var(--size);
+            background: #fff;
+            filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
+            border-radius: 50%;
+            margin-right: 6px;
+            opacity: 0.45;
+            &:last-child {
+                margin-right: 0;
+            }
+            &.is-highlighted {
+                opacity: 1;
+            }
+        }
+        .image-gallery-num {
+            margin-right: 6px;
+            opacity: 0.45;
+            &:last-child {
+                margin-right: 0;
+            }
+            &.is-highlighted {
+                opacity: 1;
+            }
+        }
+    } 
+}
+.image-gallery {
+    position: relative;
+
+    // Without this, Chrome, for some reason, automatically selects the images
+    // when clicking on the next and previous buttons quickly.
+    user-select: none;
     .image-gallery-images {
         position: relative;
         overflow: hidden;
@@ -1214,30 +1258,6 @@
             width: 0;
             height: 0;
             overflow: hidden;
-        }
-    }
-    .image-gallery-dots {
-        position: absolute;
-        z-index: 100;
-        bottom: 15px;
-        left: 50%;
-        transform: translateX(-50%);
-        display: flex;
-        .image-gallery-dot {
-            --size: 6px;
-            width: var(--size);
-            height: var(--size);
-            background: #fff;
-            filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
-            border-radius: 50%;
-            margin-right: 6px;
-            opacity: 0.45;
-            &:last-child {
-                margin-right: 0;
-            }
-            &.is-highlighted {
-                opacity: 1;
-            }
         }
     }
 }

--- a/ui/src/scss/_components.scss
+++ b/ui/src/scss/_components.scss
@@ -1151,6 +1151,46 @@
     }
 }
 
+.image-gallery {
+    position: relative;
+
+    // Without this, Chrome, for some reason, automatically selects the images
+    // when clicking on the next and previous buttons quickly.
+    user-select: none;
+    .image-gallery-images {
+        position: relative;
+        overflow: hidden;
+        .is-slot-1 {
+            position: absolute;
+            top: 0;
+            left: -100%;
+        }
+        .is-slot-3 {
+            position: absolute;
+            top: 0;
+            right: -100%;
+        }
+    }
+    .image-gallery-image {
+        background: #000;
+        height: 480px;
+        width: 100%;
+        .image {
+            width: 100%;
+            height: 100%;
+        }
+        img {
+            object-fit: contain;
+        }
+        &.is-previous,
+        &.is-next {
+            width: 0;
+            height: 0;
+            overflow: hidden;
+        }
+    }
+}
+
 .image-gallery-gutter {
     // Without this, Chrome, for some reason, automatically selects the images
     // when clicking on the next and previous buttons quickly.
@@ -1191,75 +1231,30 @@
         position: relative;
         z-index: 100;
         top: 50%;
+        transform: translateY(-50%);
+        height: fit-content;
         display: flex;
         .image-gallery-dot {
             position: relative;
             --size: 6px;
-            top:calc(1.5 * var(--size));
+            top: calc(1.5 * var(--size));
             width: var(--size);
             height: var(--size);
             background: #fff;
             filter: drop-shadow(0 0 2px rgba(0, 0, 0, 0.5));
             border-radius: 50%;
             margin-right: 6px;
-            opacity: 0.45;
             &:last-child {
                 margin-right: 0;
-            }
-            &.is-highlighted {
-                opacity: 1;
             }
         }
         .image-gallery-num {
             margin-right: 6px;
-            opacity: 0.45;
             &:last-child {
                 margin-right: 0;
             }
-            &.is-highlighted {
-                opacity: 1;
-            }
         }
     } 
-}
-.image-gallery {
-    position: relative;
-
-    // Without this, Chrome, for some reason, automatically selects the images
-    // when clicking on the next and previous buttons quickly.
-    user-select: none;
-    .image-gallery-images {
-        position: relative;
-        overflow: hidden;
-        .is-slot-1 {
-            position: absolute;
-            top: 0;
-            left: -100%;
-        }
-        .is-slot-3 {
-            position: absolute;
-            top: 0;
-            right: -100%;
-        }
-    }
-    .image-gallery-image {
-        background: #000;
-        height: 480px;
-        width: 100%;
-        .image {
-            width: 100%;
-            height: 100%;
-        }
-        img {
-            object-fit: contain;
-        }
-        &.is-previous,
-        &.is-next {
-            width: 0;
-            height: 0;
-            overflow: hidden;
-        }
-    }
 }
 
 .simple-feed {


### PR DESCRIPTION
There were a couple of posts pointing out that gallery controls/pips were obscuring some parts of larger images. There were also some requests to have the image number labelled in galleries, so they could be referred to in comments. I've combined these two requests by moving the controls and indicators into a new div below the image carousel so they will never overlap, and used a number for the current image instead of a pip. [Users also mentioned in feedback](https://discuit.org/DiscuitMeta/post/fsxIwfUf) that they preferred having consistent colours for the pips and controls, so I've removed the opacity styling.

There were also suggestions to do fancier controls that stayed on top of the image carousel but faded out after a time or by tapping the middle of the image, swiping the image or pips to navigate, but that is beyond my current skill level to implement. Such an implementation would have the advantage of keeping the post card short, instead of adding a gutter.
