### PR TITLE
UI: Flag muted comments only if not deleted to prevent auxiliary detection of username

### DIFF
--- a/core/comment.go
+++ b/core/comment.go
@@ -254,7 +254,7 @@ func scanComments(ctx context.Context, db *sql.DB, rows *sql.Rows, viewer *uid.I
 		}
 		for _, comment := range comments {
 			for _, mute := range mutes {
-				if *mute.MutedUserID == comment.AuthorID {
+				if *mute.MutedUserID == comment.AuthorID && (!comment.Deleted || viewerAdmin) {
 					comment.IsAuthorMuted = true
 					break
 				}


### PR DESCRIPTION
[Archer on the site noticed that deleted comments can leak the username using auxiliary information from muting](https://discuit.org/DiscuitMeta/post/i3Tt25Cc).

It looks like currently, only admins can see usernames of deleted comments (so mods cannot see deleted comments' usernames). I believe checking for admin status/deletion before setting the mute flag should hide this information properly, while still allowing admins to mute users.

Usernames would still be contained in the notifications in some cases, but I liken this to sending out an email recall at that point--it's not reasonable to edit the notifications that have already been sent. If those were to be fixed, I think the entire notification table would have to be scanned. Or the notifications table would have to be redesigned to split out the associated comment ID into a separate column.

