### PR TITLE
UI: Make post-voted button easier to identify

### DIFF
--- a/ui/src/scss/_home.scss
+++ b/ui/src/scss/_home.scss
@@ -210,7 +210,7 @@ a {
             // background: rgba(107, 2, 242, 0.1098039216);
             // border-color: #6b02f21f;
             svg path {
-                stroke-width: 2px;
+                stroke-width: 4px;
                 stroke: var(--color-brand);
             }
         }


### PR DESCRIPTION
[Several users are saying they have issues discerning if they voted on a post due to the colour scheme](https://discuit.org/DiscuitSuggestions/post/e_8eDZAi). I proposed making the voted triangles use a wider stroke, since that styling was already in use. It seemed four pixels was wide enough for the original poster.
