### PR TITLE
UI: suppress new list button if authed user not user being viewed

### DIFF
--- a/ui/src/pages/Lists/Lists.tsx
+++ b/ui/src/pages/Lists/Lists.tsx
@@ -144,7 +144,7 @@ const Lists = () => {
             <div className="left">
               {renderOrderDropdown()}
               {authedUser && authedUser.username === username && renderFilterDropdown()}
-              <button onClick={toggleNewListForm}>New list</button>
+              {authedUser && authedUser.username === username && <button onClick={toggleNewListForm}>New list</button>}
             </div>
           </div>
           <Modal open={isNewListOpen} onClose={toggleNewListForm}>


### PR DESCRIPTION
There is a "new list" button visible when viewing other users' list pages. This should be hidden like the filter dropdown. This is just visually confusing and not exploitable, since the backend verifies the user before creating the list.