### PR TITLE
fix docker and nix flake builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ Note: Do not install the discuit binary using `go install` or move it somewhere 
 
    > **Note**: The following command while having a persistent database, the included config.yaml file is not. You will need to mount the file to the container if you want to persist the configuration.
 
+  > **Note**: Discuit runs on port 8080 inside the container, so the 8080 outside the container doesn't matter, so long as it maps to 8080 on the inside.
+
    ```shell
-   docker run -d --name discuit -v discuit-db:/var/lib/mysql -v discuit-redis:/var/lib/redis -v discuit-images:/app/images -p 8080:80 discuit
+   docker run -d --name discuit -v discuit-db:/var/lib/mysql -v discuit-redis:/var/lib/redis -v discuit-images:/app/images -p 8080:8080 discuit
    ```
 
 3. **Accessing Discuit**: After the container starts, you can access Discuit by navigating to `http://localhost:8080` on your web browser, or to the specific port if you customized the port mapping.

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exit on error
 set -e

--- a/docker/Dockerfile.amd64
+++ b/docker/Dockerfile.amd64
@@ -19,7 +19,7 @@ COPY . .
 RUN go build -o discuit .
 
 # Use official Node image for the frontend build
-FROM node:18 AS frontend-builder
+FROM node:24 AS frontend-builder
 
 # Copy required configuration files and build files
 WORKDIR /app
@@ -34,7 +34,7 @@ RUN npm ci
 COPY ui/ . 
 
 # Final stage: setup the runtime environment
-FROM node:18
+FROM node:24
 # Avoid prompts from the package manager during build
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile.arm64
+++ b/docker/Dockerfile.arm64
@@ -20,7 +20,7 @@ COPY . .
 RUN go build -ldflags "-s -w" -o discuit .
 
 # Use official Node image for the frontend build
-FROM node:18 AS frontend-builder
+FROM node:24 AS frontend-builder
 
 # Copy required configuration files and build files
 WORKDIR /app
@@ -35,7 +35,7 @@ RUN npm ci
 COPY ui/ . 
 
 # Final stage: setup the runtime environment
-FROM node:18
+FROM node:24
 # Avoid prompts from the package manager during build
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744932701,
-        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -16,40 +16,53 @@
       system:
       let
         pkgs = import nixpkgs { inherit system; };
+
+        # Native libraries that need to be on LD_LIBRARY_PATH at runtime
+        # (e.g. libvips, which the Go vips bindings dlopen/link against)
+        libraries = with pkgs; [
+          vips
+        ];
+
+        packages = pkgs: (with pkgs; [
+          go_latest
+          nodejs_24
+          mariadb
+          redis
+          vips
+          pkg-config
+          typescript
+          vitejs
+
+          # extras
+          gotools
+          gopls
+        ]);
       in
       {
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            go_1_23
-            nodejs_18
-            mariadb
-            redis
-            vips
-            pkg-config
+        devShells.default = (pkgs.buildFHSEnv {
+          name = "discuit";
+          targetPkgs = packages;
 
-            # extras
-            gotools
-            gopls
-          ];
+          profile = ''
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath libraries}:$LD_LIBRARY_PATH
 
-          shellHook = ''
             # start mariadb
             export MYSQL_UNIX_PORT=$PWD/.mysql/mysql.sock
             export MYSQL_TCP_PORT=3306
 
             if [ ! -d .mysql ]; then
               mkdir -p .mysql
-              ${pkgs.mariadb}/bin/mysql_install_db --datadir=$PWD/.mysql
+              mysql_install_db --datadir=$PWD/.mysql
             fi
 
             # start mariadb in background
-            ${pkgs.mariadb}/bin/mysqld --datadir=$PWD/.mysql --socket=$MYSQL_UNIX_PORT > .mysql/mysql.log 2>&1 &
+            mysqld --datadir=$PWD/.mysql --socket=$MYSQL_UNIX_PORT > .mysql/mysql.log 2>&1 &
             MYSQL_PID=$!
 
             # wait for mariadb to be ready
             echo -e "\033[1;33mWaiting for mariadb to start...\033[0m"
             for i in {1..30}; do
-              if ${pkgs.mariadb}/bin/mysqladmin --socket=$MYSQL_UNIX_PORT ping &>/dev/null; then
+              if mysqladmin --socket=$MYSQL_UNIX_PORT ping &>/dev/null; then
                 echo -e "\033[1;32m✓ MariaDB is ready\033[0m"
                 break
               fi
@@ -63,14 +76,14 @@
             done
 
             echo -e "\033[1;33m  > Configuring database and user...\033[0m"
-            ${pkgs.mariadb}/bin/mysql --socket=$MYSQL_UNIX_PORT -e "CREATE DATABASE IF NOT EXISTS discuit;"
-            ${pkgs.mariadb}/bin/mysql --socket=$MYSQL_UNIX_PORT -e "CREATE USER IF NOT EXISTS 'discuit'@'127.0.0.1' IDENTIFIED BY 'discuit';"
-            ${pkgs.mariadb}/bin/mysql --socket=$MYSQL_UNIX_PORT -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'127.0.0.1';"
+            mysql --socket=$MYSQL_UNIX_PORT -e "CREATE DATABASE IF NOT EXISTS discuit;"
+            mysql --socket=$MYSQL_UNIX_PORT -e "CREATE USER IF NOT EXISTS 'discuit'@'127.0.0.1' IDENTIFIED BY 'discuit';"
+            mysql --socket=$MYSQL_UNIX_PORT -e "GRANT ALL PRIVILEGES ON discuit.* TO 'discuit'@'127.0.0.1';"
             echo -e "\033[1;32m  ✓ Database and user configured\033[0m"
 
             # start redis in background
             mkdir -p .redis
-            ${pkgs.redis}/bin/redis-server --daemonize yes --logfile .redis/redis.log
+            redis-server --daemonize yes --logfile .redis/redis.log
 
             echo ""
             echo -e "\033[1;32m✓ Environment ready for discuit development!\033[0m"
@@ -83,12 +96,14 @@
             cleanup() {
               echo -e "\n\033[1;33mShutting down services...\033[0m"
               kill $MYSQL_PID 2>/dev/null || true
-              ${pkgs.redis}/bin/redis-cli shutdown 2>/dev/null || true
+              redis-cli shutdown 2>/dev/null || true
             }
 
             trap cleanup EXIT
+
+            bash
           '';
-        };
+        }).env;
       }
     );
 }


### PR DESCRIPTION
Updated `README.md` to account for correct port exposure on docker, tested and validated.

Updated `build.sh` to invoke bash through `#!/usr/bin/env bash` which works on both traditional linux systems and NixOS.

Updated the version of node in the Dockerfiles , this fixes https://github.com/discuitnet/discuit/issues/147 

Updated the `flake.nix` to an FHS environment (thanks @gh-owner!), this also fixes the issue observed in https://github.com/discuitnet/discuit/issues/147 on nix flakes.

