### PR TITLE
feat: Add rainbow indents

### DIFF
--- a/ui/src/pages/Post/Comment.tsx
+++ b/ui/src/pages/Post/Comment.tsx
@@ -482,7 +482,10 @@ const Comment = ({
         <div className="dropdown-item" onClick={() => setConfirmDeleteOpen(true, 'admins')}>
           Delete
         </div>
-        <div className={`dropdown-item${isLocking ? ' is-disabled' : ''}`} onClick={() => !isLocking && handleLockComment('admins')}>
+        <div
+          className={`dropdown-item${isLocking ? ' is-disabled' : ''}`}
+          onClick={() => !isLocking && handleLockComment('admins')}
+        >
           {isLocking ? 'Locking...' : comment.locked ? 'Unlock comment' : 'Lock comment'}
         </div>
         {user && user.id === comment.userId && (
@@ -512,6 +515,9 @@ const Comment = ({
   const style = {
     zIndex,
   };
+  const rainbowColors = ['red', 'orange', 'yellow', 'green', 'blue', 'indigo', 'violet'];
+  const colorIndex = comment.depth % rainbowColors.length;
+  const collapseColor = rainbowColors[colorIndex];
 
   const handleLineClick: React.MouseEventHandler = (event) => {
     if (proPicRef.current) {
@@ -543,7 +549,7 @@ const Comment = ({
         <div className="post-comment-collapse" onClick={handleLineClick}>
           {/*<div className="post-comment-collapse-minus"></div>*/}
           {renderAuthorProPic()}
-          <div className="post-comment-line"></div>
+          <div className="post-comment-line" style={`--collapse-color:${collapseColor}`}></div>
         </div>
       </div>
       <div className="post-comment-body">
@@ -561,7 +567,10 @@ const Comment = ({
             </div>
           )}
           {comment.locked && (
-            <div className="post-comment-head-item post-comment-locked" title="This comment is locked. No new replies can be added.">
+            <div
+              className="post-comment-head-item post-comment-locked"
+              title="This comment is locked. No new replies can be added."
+            >
               Locked
             </div>
           )}

--- a/ui/src/pages/Post/Comment.tsx
+++ b/ui/src/pages/Post/Comment.tsx
@@ -546,7 +546,7 @@ const Comment = ({
         <div className="post-comment-collapse" onClick={handleLineClick}>
           {/*<div className="post-comment-collapse-minus"></div>*/}
           {renderAuthorProPic()}
-          <div className="post-comment-line" style={`--collapse-color:${collapseColor}`}></div>
+          <div className="post-comment-line" style={{ '--collapse-color': collapseColor }}></div>
         </div>
       </div>
       <div className="post-comment-body">

--- a/ui/src/pages/Post/Comment.tsx
+++ b/ui/src/pages/Post/Comment.tsx
@@ -482,10 +482,7 @@ const Comment = ({
         <div className="dropdown-item" onClick={() => setConfirmDeleteOpen(true, 'admins')}>
           Delete
         </div>
-        <div
-          className={`dropdown-item${isLocking ? ' is-disabled' : ''}`}
-          onClick={() => !isLocking && handleLockComment('admins')}
-        >
+        <div className={`dropdown-item${isLocking ? ' is-disabled' : ''}`} onClick={() => !isLocking && handleLockComment('admins')}>
           {isLocking ? 'Locking...' : comment.locked ? 'Unlock comment' : 'Lock comment'}
         </div>
         {user && user.id === comment.userId && (
@@ -567,10 +564,7 @@ const Comment = ({
             </div>
           )}
           {comment.locked && (
-            <div
-              className="post-comment-head-item post-comment-locked"
-              title="This comment is locked. No new replies can be added."
-            >
+            <div className="post-comment-head-item post-comment-locked" title="This comment is locked. No new replies can be added.">
               Locked
             </div>
           )}


### PR DESCRIPTION
The indentation line will cycle through the list of colors defined in `rainbowColors` with increasing depth. This is an implementation of the idea proposed in https://discuit.org/DiscuitSuggestions/post/eeWRWuyZ

Currently the colors are just the names of the colors of the rainbow, though they should probably be tested for visibility/accessibility and replaced with better CSS color codes.

I haven't tested whether this actually works as I am unable to get Discuit running on my Mac. It's a simple enough change that I don't think anything should break, but if someone would be willing to test it and let me know, I'd appreciate it.

I also found what appears to be a previous attempt at this:

https://github.com/discuitnet/discuit/blob/e0d7afea480298d3a62574be5fed94bd472888e0/ui/src/scss/_post.scss#L359-L381

If you'd like, I can remove those lines, though they're already commented out.