### PR TITLE
fix: error and warning messages

### DIFF
--- a/ui/src/pages/NewPost/Image.tsx
+++ b/ui/src/pages/NewPost/Image.tsx
@@ -76,7 +76,7 @@ const Image = ({
         />
       )}
       {(!disabled || isEditMode) && (
-        <Button className="button-alt-text" onClick={() => setModalOpen(true)}>
+        <Button className={clsx("button-alt-text", missingAltText && 'is-error')} onClick={() => setModalOpen(true)}>
           Alt text
         </Button>
       )}

--- a/ui/src/pages/NewPost/index.tsx
+++ b/ui/src/pages/NewPost/index.tsx
@@ -293,14 +293,9 @@ const NewPost = () => {
           }),
         });
         if (!res.ok) {
-          if (res.status === 400) {
-            const error = await res.json();
-            if (error.code === 'invalid-url') {
-              dispatch(snackAlert('The URL you provided is not a valid URL.'));
-              return;
-            }
-          }
-          throw new APIError(res.status, await res.json());
+          const error = await res.json();
+          dispatch(snackAlert(error.message));
+          return;
         }
         newPost = await res.json();
       }
@@ -623,6 +618,14 @@ const NewPost = () => {
               Submit
             </button>
             <button onClick={handleCancel}>Cancel</button>
+            {
+              isAltMissing()
+                ? <div className="form-field">
+                    <div className="form-error text-center">Your settings require alt text.</div>
+                  </div>
+                : ''
+            }
+
           </div>
         </div>
         <div className="new-page-sidebar">

--- a/ui/src/pages/Post/AddComment.tsx
+++ b/ui/src/pages/Post/AddComment.tsx
@@ -2,10 +2,9 @@ import { useCallback, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
 import MarkdownTextarea from '../../components/MarkdownTextarea';
-import { APIError, mfetch } from '../../helper';
+import { mfetch } from '../../helper';
 import { Comment } from '../../serverTypes';
 import {
-  bannedFromAdded,
   loginPromptToggled,
   snackAlert,
   snackAlertError,
@@ -97,19 +96,15 @@ const AddComment = ({
         });
       }
       if (!res.ok) {
-        if (res.status === 403) {
-          const json = await res.json();
-          if (json.code === 'banned_from_community') {
-            alert('You are banned from this community.');
-            dispatch(bannedFromAdded(post.communityId));
-            return;
-          }
-        } else if (res.status === 429) {
+        if (res.status === 429) {
           // Try again in 2 seconds.
           timer.current = window.setTimeout(handleSubmit, 2000);
           return;
+        } else {
+          const error = await res.json();
+          dispatch(snackAlert(error.message));
+          return;
         }
-        throw new APIError(res.status, await res.json());
       }
       const comm = (await res.json()) as Comment;
       reset();

--- a/ui/src/scss/_newPost.scss
+++ b/ui/src/scss/_newPost.scss
@@ -288,6 +288,10 @@
                         left: 8px;
                         background-color: var(--button-background);
                         color: var(--color);
+                        &.is-error {
+                            color: var(--color-red);
+                            text-decoration: underline;
+                        }
                     }
                     .button-close,
                     .button-alt-text {


### PR DESCRIPTION
A couple of complaints recently about inscrutable warnings and errors.

[One user spent a day wondering why they couldn't post pictures](https://discuit.org/DiscuitMeta/post/zXbYDfrj). It was because they had toggled "require alt text" in their settings, but the UI has no warning about this.

[Additionally, it seems some hard-coded error messaging in the UI doesn't match the values that the server sends](https://discuit.org/Selfposting/post/q1isgVxV). E.g., for some ban snack alerts, the UI expects `banned_from_community` while the server sends [with hyphens instead of underscores](https://github.com/discuitnet/discuit/blob/297401134fd9d102e40a275606d0e384e1eb6eb3/core/errors.go#L27). I figure it's easier to just propagate the error object from the server directly, so the `throw new APIError...` can just be removed.